### PR TITLE
PerformanceObserver.observe() needs 'target'

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,11 +145,12 @@
     <ul>
       <li>MUST extend the <a>PerformanceEntry</a> interface</li>
       <li>MUST be supported by the <a href="#widl-Performance-getEntries-PerformanceEntryList">getEntries</a>, <a href="#widl-Performance-getEntriesByType-PerformanceEntryList">getEntriesByType</a>, and <a href="#widl-Performance-getEntriesByName-PerformanceEntryList">getEntriesByName</a> methods.</li>
-      <li>SHOULD surface new performance metrics in a timely manner</li>
+      <li>SHOULD surface new performance metrics in a timely manner
       <ul>
         <li>The user agent is NOT REQUIRED to provide synchronous access to new performance metrics</li>
         <li>The user agent MAY delay reporting the metric to avoid performance bottlenecks</li>
       </ul>
+      </li>
     </ul>
 
       <section>
@@ -191,15 +192,17 @@
             <ol>
               <li>Let the <dfn>list of entry objects</dfn> be the empty <a>PerformanceEntryList</a>.</li>
               <li> Let the <dfn>set of filter properties</dfn> be a set of pairs where the first element is the _name_ of a <a href="http://www.w3.org/TR/WebIDL/#dfn-dictionary-member">dictionary member</a> of `filter` that is present and the second element is the _value_ of that <a href="http://www.w3.org/TR/WebIDL/#dfn-dictionary-member">dictionary member</a>.</li>
-              <li>For each available <a>PerformanceEntry</a> object (<dfn>entryObject</dfn>), in chronological order with respect to <a href="#widl-PerformanceEntry-startTime">startTime</a>:</li>
+              <li>For each available <a>PerformanceEntry</a> object (<dfn>entryObject</dfn>), in chronological order with respect to <a href="#widl-PerformanceEntry-startTime">startTime</a>:
                 <ol>
-                <li>For each _name_ and _value_ pair in <a>set of filter properties</a>:</li>
+                <li>For each _name_ and _value_ pair in <a>set of filter properties</a>:
                   <ol>
                   <li>If the <a>entryObject</a> does not contain an attribute whose name matches _name_, go to next <a>entryObject</a>.</li>
                   <li>Otherwise, if the <a>entryObject</a> contains an attribute whose name matches _name_, and its value does not match _value_, go to next <a>entryObject</a>.</li>
                   </ol>
+                </li>
                 <li>Add <a>entryObject</a> to the <a>list of entry objects</a>.</li>
                 </ol>
+              </li>
               <li>Return the <a>list of entry objects</a>.</li>
             </ol>
           </dd>

--- a/index.html
+++ b/index.html
@@ -227,7 +227,7 @@
       <dl title='[Constructor(PerformanceObserverCallback callback), Exposed=(Window,Worker)] interface PerformanceObserver' class='idl'>
 
         <dt>void observe(PerformanceObserverInit options)</dt>
-        <dd>This method instructs the user agent to <dfn>register the observer</dfn> and report any new performance entries based on the criteria given by <i>options</i>.
+        <dd>This method instructs the user agent to <dfn>register the observer</dfn> and report any new performance entries based on the criteria given by _options_.
           <dl title='dictionary PerformanceObserverInit' class='idl'>
             <dt>required sequence&lt;DOMString&gt; typeFilter</dt>
             <dd>

--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
   </section>
 
   <section id='sotd'>
+    <p>This new version is aligned with [[HR-TIME-2]] and introduces <a href='#dictionary-filteroptions-members'>filtering</a> and <a href="#the-performance-observer-interface">performance observers</a>.</p>
     <p>This is a <strong>work in progress</strong> and may change without any notices.</p>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
 
     <ul>
       <li>MUST extend the <a>PerformanceEntry</a> interface</li>
-      <li>MUST be supported by the <a href="#widl-Performance-getEntries-PerformanceEntryList">getEntries</a>, <a href="#widl-Performance-getEntriesByType-PerformanceEntryList">getEntriesByType</a>, and <a href="#widl-Performance-getEntriesByName-PerformanceEntryList">getEntriesByName</a> methods.</li>
+      <li>MUST be supported by the <a href="#widl-PerformanceObserverEntryList-getEntries-PerformanceEntryList-FilterOptions-filter">getEntries</a>, <a href="#widl-PerformanceObserverEntryList-getEntriesByType-PerformanceEntryList-DOMString-entryType">getEntriesByType</a>, and <a href="#widl-PerformanceObserverEntryList-getEntriesByName-PerformanceEntryList-DOMString-name-DOMString-entryType">getEntriesByName</a> methods.</li>
       <li>SHOULD surface new performance metrics in a timely manner
       <ul>
         <li>The user agent is NOT REQUIRED to provide synchronous access to new performance metrics</li>
@@ -163,9 +163,9 @@
           <dt>readonly attribute DOMString entryType</dt>
           <dd>This attribute MUST return a <a href="http://www.w3.org/TR/WebIDL/#idl-DOMString">DOMString</a> that describes the <a href="http://www.w3.org/wiki/Web_Performance/EntryType">type of the interface</a> represented by this <a>PerformanceEntry</a> object.</dd>
           <dt>readonly attribute DOMString startTime</dt>
-          <dd>The attribute MUST return a <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp">DOMHighResTimeStamp</a> that contains the time value of the first recorded timestamp of this performance metric.</dd>
+          <dd>The attribute MUST return a <a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">DOMHighResTimeStamp</a> that contains the time value of the first recorded timestamp of this performance metric.</dd>
           <dt>readonly attribute DOMString duration</dt>
-          <dd>The attribute MUST return a <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp">DOMHighResTimeStamp</a> that contains the time value of the duration of the entire event being recorded by this <a>PerformanceEntry</a>. Typically, this would be the time difference between the last recorded timestamp and the first recorded timestamp of this <a>PerformanceEntry</a>. If the duration concept doesn't apply, a performance metric may choose to return a `duration` of 0.</dd>
+          <dd>The attribute MUST return a <a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">DOMHighResTimeStamp</a> that contains the time value of the duration of the entire event being recorded by this <a>PerformanceEntry</a>. Typically, this would be the time difference between the last recorded timestamp and the first recorded timestamp of this <a>PerformanceEntry</a>. If the duration concept doesn't apply, a performance metric may choose to return a `duration` of 0.</dd>
           <dt>serializer = { attribute }</dt>
         </dl>
       </section>
@@ -173,7 +173,7 @@
       <section>
         <h2>Extensions to the <dfn>Performance</dfn> interface</h2>
 
-        <p>This extends the <a href='http://www.w3.org/TR/hr-time/#idl-def-Performance'>Performance</a> interface [[!HR-TIME-2]] and hosts performance related attributes and methods used to retrieve the performance metric data from the <a>Performance Timeline</a>.</p>
+        <p>This extends the <a href='https://w3c.github.io/hr-time/#idl-def-Performance'>Performance</a> interface [[!HR-TIME-2]] and hosts performance related attributes and methods used to retrieve the performance metric data from the <a>Performance Timeline</a>.</p>
 
         <dl title='dictionary FilterOptions' class='idl'>
           <dt>DOMString name</dt>
@@ -273,11 +273,11 @@
 
         <dl title='[Exposed=(Window,Worker)] interface PerformanceObserverEntryList' class='idl'>
           <dt>PerformanceEntryList getEntries(optional FilterOptions filter)</dt>
-          <dd>See <a href="#widl-Performance-getEntries-PerformanceEntryList">performance.getEntries</a>.</dd>
+          <dd>See <a href="#widl-PerformanceObserverEntryList-getEntries-PerformanceEntryList-FilterOptions-filter">performance.getEntries</a>.</dd>
           <dt>PerformanceEntryList getEntriesByType(DOMString entryType)</dt>
-          <dd>See <a href="#widl-Performance-getEntriesByType-PerformanceEntryList">performance.getEntriesByType</a>.</dd>
+          <dd>See <a href="#widl-PerformanceObserverEntryList-getEntriesByType-PerformanceEntryList-DOMString-entryType">performance.getEntriesByType</a>.</dd>
           <dt>PerformanceEntryList getEntriesByName(DOMString name, optional DOMString entryType)</dt>
-          <dd>See <a href="#widl-Performance-getEntriesByName-PerformanceEntryList">performance.getEntriesByName</a>.</dd>
+          <dd>See <a href="#widl-PerformanceObserverEntryList-getEntriesByName-PerformanceEntryList-DOMString-name-DOMString-entryType">performance.getEntriesByName</a>.</dd>
         </dl>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -280,19 +280,7 @@
           <dd>See <a href="#widl-PerformanceObserverEntryList-getEntriesByName-PerformanceEntryList-DOMString-name-DOMString-entryType">performance.getEntriesByName</a>.</dd>
         </dl>
       </section>
-
     </section>
-  </section>
-
-
-  <section>
-    <h2>Vendor Extensions</h2>
-    <p>If a vendor-specific proprietary user agent extension is needed to create experimental <a>PerformanceEntry</a> objects, on getting the <a href="#idl-PerformanceEntry-entryType">entryType</a> IDL attribute, vendors MUST return a `DOMString` that uses the following convention:</p>
-    <pre>[vendorPrefix]-[entryType]</pre>
-    <p>Where, `[vendorPrefix]` is a non-capitalized name that identifies the vendor, `[entryType]` is a non-capitalized name given to the type of   interface represented by this <a>PerformanceEntry</a> object, and the above names are in ASCII.</p>
-  </section>
-
-
   </section>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -241,8 +241,9 @@
             </dd>
           </dl>
 
-          <p>The `observe(options)` method must run these steps:</p>
+          <p>The `observe(target, options)` method must run these steps:</p>
           <ol>
+            <li>If `target` is not valid, <a href="http://heycam.github.io/webidl/#dfn-throw">throw</a> a JavaScript `TypeError`.</li>
             <li>If _options'_ `typeFilter` attribute is not present, <a href="http://heycam.github.io/webidl/#dfn-throw">throw</a> a JavaScript `TypeError`.</li>
             <li>Filter unsupported <a href="#widl-PerformanceEntry-entryType">entryType names</a> within the `typeFilter` sequence, and replace the `typeFilter` sequence with the new filtered sequence.</li>
             <li>If the _options'_ `typeFilter` attribute is an empty sequence, <a href="http://heycam.github.io/webidl/#dfn-throw">throw</a> a JavaScript `TypeError`.</li>

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
     });
 
     // subscribe to Frame-Timing and User-Timing events
-    observer.observe(window.performance, {typeFilter: ['render', 'composite', 'mark', 'measure']});
+    observer.observe({typeFilter: ['render', 'composite', 'mark', 'measure']});
     &lt;/script&gt;
   &lt;/body&gt;
 &lt;/html&gt;
@@ -233,8 +233,8 @@
 
       <dl title='[Constructor(PerformanceObserverCallback callback), Exposed=(Window,Worker)] interface PerformanceObserver' class='idl'>
 
-        <dt>void observe(Performance target, PerformanceObserverInit options)</dt>
-        <dd>This method instructs the user agent to <dfn>register the observer</dfn> for <i>target</i> and report any new performance entries based on the criteria given by <i>options</i>.
+        <dt>void observe(PerformanceObserverInit options)</dt>
+        <dd>This method instructs the user agent to <dfn>register the observer</dfn> and report any new performance entries based on the criteria given by <i>options</i>.
           <dl title='dictionary PerformanceObserverInit' class='idl'>
             <dt>required sequence&lt;DOMString&gt; typeFilter</dt>
             <dd>
@@ -248,9 +248,8 @@
             </dd>
           </dl>
 
-          <p>The `observe(target, options)` method must run these steps:</p>
+          <p>The `observe(options)` method must run these steps:</p>
           <ol>
-            <li>If `target` is not valid, <a href="http://heycam.github.io/webidl/#dfn-throw">throw</a> a JavaScript `TypeError`.</li>
             <li>If _options'_ `typeFilter` attribute is not present, <a href="http://heycam.github.io/webidl/#dfn-throw">throw</a> a JavaScript `TypeError`.</li>
             <li>Filter unsupported <a href="#widl-PerformanceEntry-entryType">entryType names</a> within the `typeFilter` sequence, and replace the `typeFilter` sequence with the new filtered sequence.</li>
             <li>If the _options'_ `typeFilter` attribute is an empty sequence, <a href="http://heycam.github.io/webidl/#dfn-throw">throw</a> a JavaScript `TypeError`.</li>

--- a/index.html
+++ b/index.html
@@ -241,9 +241,8 @@
             </dd>
           </dl>
 
-          <p>The `observe(target, options)` method must run these steps:</p>
+          <p>The `observe(options)` method must run these steps:</p>
           <ol>
-            <li>If `target` is not valid, <a href="http://heycam.github.io/webidl/#dfn-throw">throw</a> a JavaScript `TypeError`.</li>
             <li>If _options'_ `typeFilter` attribute is not present, <a href="http://heycam.github.io/webidl/#dfn-throw">throw</a> a JavaScript `TypeError`.</li>
             <li>Filter unsupported <a href="#widl-PerformanceEntry-entryType">entryType names</a> within the `typeFilter` sequence, and replace the `typeFilter` sequence with the new filtered sequence.</li>
             <li>If the _options'_ `typeFilter` attribute is an empty sequence, <a href="http://heycam.github.io/webidl/#dfn-throw">throw</a> a JavaScript `TypeError`.</li>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <title>Performance Timeline</title>
   <meta charset='utf-8'>
-  <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
+  <script src='//www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
   <script class='remove'>
   var respecConfig = {
     shortName: "performance-timeline",
@@ -53,7 +53,7 @@
 
 <body>
   <section id='abstract'>
-    <p>This specification extends the High Resolution Time specification [[!HR-TIME-2]] by providing methods to store and retrieve high resolution performance metric data.</p>
+    <p>This specification defines a unified interface to store and retrieve high resolution performance metric data.</p>
   </section>
 
   <section id='sotd'>
@@ -65,7 +65,7 @@
 
     <p>Accurately measuring performance characteristics of web applications is an important aspect of making web applications faster. This specification defines the necessary <a>Performance Timeline</a> primitives that enable web developers to access, instrument, and retrieve various performance metrics from the full lifecycle of a web application.</p>
 
-    <p>[[NAVIGATION-TIMING-2]], [[RESOURCE-TIMING]], and [[USER-TIMING]] are examples of specifications that define timing information related to the navigation of the document, resources on the page, and developer scripts, respectively. Together these and other performance interfaces define performance metrics that describe the <a>Performance Timeline</a> of a web application. For example, the following script shows how a developer can access the <a>Performance Timeline</a> to obtain performance metrics related to the navigation of the document, resources on the page, and developer scripts:</p>
+    <p>[[NAVIGATION-TIMING]], [[RESOURCE-TIMING]], and [[USER-TIMING]] are examples of specifications that define timing information related to the navigation of the document, resources on the page, and developer scripts, respectively. Together these and other performance interfaces define performance metrics that describe the <a>Performance Timeline</a> of a web application. For example, the following script shows how a developer can access the <a>Performance Timeline</a> to obtain performance metrics related to the navigation of the document, resources on the page, and developer scripts:</p>
 
     <pre class="highlight example">
 &lt;!doctype html&gt;
@@ -173,9 +173,35 @@
 
         <p>This extends the <a href='http://www.w3.org/TR/hr-time/#idl-def-Performance'>Performance</a> interface [[!HR-TIME-2]] and hosts performance related attributes and methods used to retrieve the performance metric data from the <a>Performance Timeline</a>.</p>
 
+        <dl title='dictionary FilterOptions' class='idl'>
+          <dt>DOMString name</dt>
+          <dd><a href="#widl-PerformanceEntry-name">name</a> of `PerformanceEntry` object.</dd>
+          <dt>DOMString entryType</dt>
+          <dd><a href="#widl-PerformanceEntry-type">entryType</a> of `PerformanceEntry` object.</dd>
+          <dt>DOMString initiatorType</dt>
+          <dd><a href="http://www.w3.org/TR/resource-timing/#widl-PerformanceResourceTiming-initiatorType">initiatorType</a> of `PerformanceEntry` object.</dd>
+        </dl>
+
         <dl title='partial interface Performance' class='idl'>
-          <dt>PerformanceEntryList getEntries()</dt>
-          <dd>This method returns a <a>PerformanceEntryList</a> object that contains a copy of all <a>PerformanceEntry</a> objects in chronological order with respect to <a href="#widl-PerformanceEntry-startTime">startTime</a>.</dd>
+          <dt>PerformanceEntryList getEntries(optional FilterOptions filter)</dt>
+          <dd>
+            <p>This method returns a <a>PerformanceEntryList</a> object that contains a list of <a>PerformanceEntry</a> objects, sorted in chronological order with respect to <a href="#widl-PerformanceEntry-startTime">startTime</a>, that match the following criteria:</p>
+
+            <ol>
+              <li>Let the <dfn>list of entry objects</dfn> be the empty <a>PerformanceEntryList</a>.</li>
+              <li> Let the <dfn>set of filter properties</dfn> be a set of pairs where the first element is the _name_ of a <a href="http://www.w3.org/TR/WebIDL/#dfn-dictionary-member">dictionary member</a> of `filter` that is present and the second element is the _value_ of that <a href="http://www.w3.org/TR/WebIDL/#dfn-dictionary-member">dictionary member</a>.</li>
+              <li>For each available <a>PerformanceEntry</a> object (<dfn>entryObject</dfn>), in chronological order with respect to <a href="#widl-PerformanceEntry-startTime">startTime</a>:</li>
+                <ol>
+                <li>For each _name_ and _value_ pair in <a>set of filter properties</a>:</li>
+                  <ol>
+                  <li>If the <a>entryObject</a> does not contain an attribute whose name matches _name_, go to next <a>entryObject</a>.</li>
+                  <li>Otherwise, if the <a>entryObject</a> contains an attribute whose name matches _name_, and its value does not match _value_, go to next <a>entryObject</a>.</li>
+                  </ol>
+                <li>Add <a>entryObject</a> to the <a>list of entry objects</a>.</li>
+                </ol>
+              <li>Return the <a>list of entry objects</a>.</li>
+            </ol>
+          </dd>
 
           <dt>PerformanceEntryList getEntriesByType(DOMString entryType)</dt>
           <dd>This method returns a <a>PerformanceEntryList</a> object returned by `getEntries({'entryType': entryType})`.</dd>

--- a/index.html
+++ b/index.html
@@ -162,9 +162,9 @@
           <dd>The attribute MUST return a <a href="http://www.w3.org/TR/WebIDL/#idl-DOMString">DOMString</a> identifier for this <a>PerformanceEntry</a> object. This identifier does not have to be unique.</dd>
           <dt>readonly attribute DOMString entryType</dt>
           <dd>This attribute MUST return a <a href="http://www.w3.org/TR/WebIDL/#idl-DOMString">DOMString</a> that describes the <a href="http://www.w3.org/wiki/Web_Performance/EntryType">type of the interface</a> represented by this <a>PerformanceEntry</a> object.</dd>
-          <dt>readonly attribute DOMString startTime</dt>
+          <dt>readonly attribute DOMHighResTimeStamp startTime</dt>
           <dd>The attribute MUST return a <a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">DOMHighResTimeStamp</a> that contains the time value of the first recorded timestamp of this performance metric.</dd>
-          <dt>readonly attribute DOMString duration</dt>
+          <dt>readonly attribute DOMHighResTimeStamp duration</dt>
           <dd>The attribute MUST return a <a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">DOMHighResTimeStamp</a> that contains the time value of the duration of the entire event being recorded by this <a>PerformanceEntry</a>. Typically, this would be the time difference between the last recorded timestamp and the first recorded timestamp of this <a>PerformanceEntry</a>. If the duration concept doesn't apply, a performance metric may choose to return a `duration` of 0.</dd>
           <dt>serializer = { attribute }</dt>
         </dl>

--- a/index.html
+++ b/index.html
@@ -1,188 +1,75 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
+
 <head>
-  <meta charset="utf-8">
   <title>Performance Timeline</title>
-<style type="text/css">
-   pre.idl { border:solid thin; background:#eee; color:#000; padding:0.5em }
-   pre.idl :link, pre.idl :visited { color:inherit; background:transparent }
-   pre code { color:inherit; background:transparent }
-   div.example { margin-left:1em; padding-left:1em; border-left:double; color:#222; background:#fcfcfc }
-   .note { margin-left:2em; font-weight:bold; font-style:italic; color:#008000 }
-   p.note::before { content:"Note: " }
-   .XXX { padding:.5em; border:solid #f00 }
-   p.XXX::before { content:"Issue: " }
-   dl.switch { padding-left:2em }
-   dl.switch > dt { text-indent:-1.5em }
-   dl.switch > dt:before { content:'\21AA'; padding:0 0.5em 0 0; display:inline-block; width:1em; text-align:right; line-height:0.5em }
-   dl.domintro { color: green; margin: 2em 0 2em 2em; padding: 0.5em 1em; border: none; background: #DDFFDD; }
-   dl.domintro dt, dl.domintro dt * { color: black; text-decoration: none; }
-   dl.domintro dd { margin: 0.5em 0 1em 2em; padding: 0; }
-   dl.domintro dd p { margin: 0.5em 0; }
-   dl.domintro:before { display: table; margin: -1em -0.5em -0.5em auto; width: auto; content: 'This box is non-normative. Implementation requirements are given below this box.'; color: red; border: solid 2px; background: white; padding: 0 0.25em; }
-   em.ct { text-transform:lowercase; font-variant:small-caps; font-style:normal }
-   dfn { font-weight:bold; font-style:normal }
-   code { color:orangered }
-   code :link, code :visited { color:inherit }
-   hr:not(.top) { display:block; background:none; border:none; padding:0; margin:2em 0; height:auto }
-   table { border-collapse:collapse; border-style:hidden hidden none hidden }
-   table thead { border-bottom:solid }
-   table tbody th:first-child { border-left:solid }
-   table td, table th { border-left:solid; border-right:solid; border-bottom:solid thin; vertical-align:top; padding:0.2em }
-   div.parameters { display:block; margin-left: 25px;}
-   div.parameterDefinition { display:block; margin-left: 25px;}
-   div.methods { display:block; margin-top:30px; margin-left :25px;}
-  </style>
-  <link href="https://www.w3.org/StyleSheets/TR/W3C-ED.css" rel="stylesheet" type="text/css">
+  <meta charset='utf-8'>
+  <script src='//www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
+  <script class='remove'>
+  var respecConfig = {
+    shortName: "performance-timeline",
+    specStatus: "ED",
+    edDraftURI: "https://w3c.github.io/performance-timeline/",
+    // publishDate: "2013-10-23",
+    editors: [{
+      name: "Ilya Grigorik",
+      url: "https://www.igvita.com/",
+      mailto: "igrigorik@gmail.com",
+      company: "Google",
+      companyURL: "https://www.google.com/",
+      w3cid: "56102"
+    },{
+      name: "Jatinder Mann",
+      mailto: "jmann@microsoft.com",
+      company: "Microsoft Corp.",
+      note: "Until November 2014"
+    },{
+      name: "Zhiheng Wang",
+      company: "Google",
+      note: "Until July 2013"
+    }],
+    wg: "Web Performance Working Group",
+    wgURI: "http://www.w3.org/2010/webperf/",
+    wgPublicList: "public-web-perf",
+    subjectPrefix: "[Performance Timeline]",
+    format: "markdown",
+    otherLinks: [{
+      key: 'Repository',
+      data: [{
+        value: 'We are on GitHub',
+        href: 'https://github.com/w3c/performance-timeline/'
+      }, {
+        value: 'Commit history',
+        href: 'https://github.com/w3c/performance-timeline/commits/gh-pages/index.html'
+      }, {
+        value: 'File a bug',
+        href: 'https://github.com/w3c/performance-timeline/issues'
+      }]
+    }],
+    wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/45211/status"
+  };
+  </script>
 </head>
 
-<body class="draft">
+<body>
+  <section id='abstract'>
+    <p>This specification defines an unified interface to store and retrieve performance metric data. This specification does not cover individual performance metric interfaces.</p>
+  </section>
 
-<div class="head">
-<h1>Performance Timeline</h1>
+  <section id='sotd'>
+    <p>This is a <strong>work in progress</strong> and may change without any notices.</p>
+  </section>
 
-<h2 class="no-num no-toc" id="editors-draft-october-23-2013">Editor's Draft October 23, 2013</h2>
-<dl>
-  <dt>This version:</dt>
-    <dd><a
-      href="https://w3c.github.io/performance-timeline/">https://w3c.github.io/performance-timeline/</a></dd>
-  <dt>Latest version:</dt>
-    <dd><a
-      href="http://www.w3.org/TR/performance-timeline/">http://www.w3.org/TR/performance-timeline/</a></dd>
-  <dt>Latest Editor's Draft:</dt>
-    <dd><a
-      href="https://w3c.github.io/performance-timeline/">https://w3c.github.io/performance-timeline/</a></dd>
-  <dt>Previous version:</dt>
-    <dd><a
-      href="https://w3c.github.io/performance-timeline/">https://w3c.github.io/performance-timeline/</a></dd>
-  <dt>Editors:</dt>
-    <dd class="vcard"><span class="fn">Ilya Grigorik</span>, <span
-      class="org">Google Inc.</span>, &lt;<a
-      class="email" href="mailto:igrigorik@gmail.com">igrigorik@gmail.com</a>&gt;</dd>
-    <dd class="vcard"><span class="fn">Jatinder Mann</span>, <span
-      class="org">Microsoft Corp.</span>, &lt;<a
-      class="email" href="mailto:jmann@microsoft.com">jmann@microsoft.com</a>&gt; (Until Nov 2014)</dd>
-    <dd class="vcard"><span class="fn">Zhiheng Wang</span>, <span
-      class="org">Google Inc.</span> (Until July 2013)</dd>
-</dl>
+  <section class='informative'>
+    <h2>Introduction</h2>
 
-   <p class=copyright><a
-    href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>
-    &copy; 2012 <a href="http://www.w3.org/"><abbr title="World Wide Web
-    Consortium">W3C</abbr></a><sup>&reg;</sup> (<a
-    href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute
-    of Technology">MIT</abbr></a>, <a
-    href="http://www.ercim.eu/"><abbr title="European Research Consortium
-    for Informatics and Mathematics">ERCIM</abbr></a>, <a
-    href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a
-    href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-    <a
-    href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>
+    <p>Accurately measuring performance characteristics of web applications is an important aspect of making web applications faster. [[NAVIGATION-TIMING]], [[RESOURCE-TIMING]], and [[USER-TIMING]] are examples of specifications that define timing information related to the navigation of the document, resources on the page, and developer scripts, respectively.</p>
 
-    and <a
-    href="http://www.w3.org/Consortium/Legal/copyright-documents">document
-    use</a> rules apply.</p>
+    <p>Together these interfaces, and potentially others created in the future, define performance metrics that describe the performance timeline of a web application. This specification provides an unifying interface to access and retrieve these various performance metrics from the performance timeline of a web application.</p>
 
-   <hr class='top'>
-</div>
+    <p>The following script shows how a developer can use the <a>PerformanceEntry</a> interface to obtain timing data related to the navigation of the document, resources on the page and developer scripts.</p>
 
-<h2 class="no-num no-toc" id="abstract">Abstract</h2>
-
-<p>This specification defines an unified interface to store and retrieve performance metric data.
-This specification does not cover individual performance metric interfaces.</p>
-
-<h2 class="no-num no-toc" id="status-of-this-document">Status of this
-document</h2>
-
-  <p><em>This section describes the status of this document at the time of
-   its publication. Other documents may supersede this document. A list of
-   current W3C publications and the latest revision of this technical report
-   can be found in the <a href="http://www.w3.org/TR/">W3C technical reports
-   index</a> at http://www.w3.org/TR/.</em></p>
-
-<p>This is a <strong>work in progress</strong> and may change without any
-notices. </p>
-
-<p>Please send comments
-   to <a href="mailto:public-web-perf@w3.org?subject=%5BPerformanceTimeline%5D%20">public-web-perf@w3.org</a>
-   (<a href="http://lists.w3.org/Archives/Public/public-web-perf/">archived</a>)
-   with <samp>[PerformanceTimeline]</samp> at the start of the subject line.</p>
-
-<p>This document is produced by
-   the <a href="http://www.w3.org/2010/webperf/">Web Performance</a>
-   Working Group. The Web Performance Working Group is part of
-   the <a href="http://www.w3.org/2006/rwc/Activity">Rich Web Clients
-   Activity</a> in the
-   W3C <a href="http://www.w3.org/Interaction/">Interaction
-   Domain</a>.
-
-<p>Publication as a Working Draft does not imply endorsement by the
-W3C Membership. This is a draft document and may be updated, replaced
-or obsoleted by other documents at any time. It is inappropriate to
-cite this document as other than work in progress. </p>
-
-<p>This document was produced by a group operating under
-   the <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5
-   February 2004 W3C Patent Policy</a>. W3C maintains
-   a <a href="http://www.w3.org/2004/01/pp-impl/45211/status"
-   rel="disclosure">public list of any patent disclosures</a> made in
-   connection with the deliverables of the group; that page also
-   includes instructions for disclosing a patent. An individual who
-   has actual knowledge of a patent which the individual believes
-   contains <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
-   Claim(s)</a> must disclose the information in accordance
-   with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
-   6 of the W3C Patent Policy</a>.</p>
-
-
-<h2 class="no-num no-toc" id="table-of-contents">Table of Contents</h2>
-<!--begin-toc-->
-<ol class="toc">
-  <li><a href="#introduction"><span class="secno">1
-  </span>Introduction</a></li>
-  <li><a href="#conformance-requirements"><span class="secno">2
-    </span>Conformance requirements</a></li>
-  <li><a href="#terminology"><span class="secno">3 </span>Terminology</a></li>
-  <li><a href="#sec-navigation-timing"><span class="secno">4 </span>Performance Timeline</a>
-    <ol class="toc">
-      <li><a href="#sec-performance-timeline"><span class="secno">4.1 </span> The Performance Timeline</a></li>
-      <li><a href="#sec-PerformanceEntry-interface"><span class="secno">4.2 </span>The <code>PerformanceEntry</code> interface</a></li>
-      <li><a href="#sec-window.performance-attribute"><span class="secno">4.3 </span> Extensions to the <code>Performance</code> interface</a></li>
-      <li><a href="#sec-vendor-extensions"><span class="secno">4.4 </span> Vendor Extensions</a></li>
-    </ol>
-  </li>
-  <li><a href="#references"><span class="secno">5 </span>References</a></li>
-  <li><a class="no-num" href="#acknowledgements">Acknowledgements</a></li>
-</ol>
-<!--end-toc-->
-
-
-<h2 id="introduction"><span class="secno">1 </span>Introduction</h2>
-
-<p>This section is non-normative.</p>
-
-<p>
-Accurately measuring performance characteristics of web applications
-is an important aspect of making web applications
-faster. <a href='#NavigationTiming'>[Navigation
-Timing]</a>, <a href='#ResourceTiming'>[Resource Timing]</a>,
-and <a href='#UserTiming'>[User Timing]</a> are examples of
-specifications that define timing information related to the
-navigation of the document, resources on the page, and developer
-scripts, respectively.
-</p>
-<p>
-Together these interfaces, and potentially others created in the future, define performance metrics
-that describe the performance timeline of a web application. This
-specification provides an unifying interface to access and retrieve these various performance metrics from the performance timeline of a
-web application.
-</p>
-
-<div class="example">
-<p>The following script shows how a developer can use the <a href="#performanceentry"><code>PerformanceEntry</code></a> interface
-to obtain timing data related to the navigation of the document, resources on the page and developer scripts.
-</p>
-<pre>
+    <pre class="highlight example">
 &lt;!doctype html&gt;
 &lt;html&gt;
   &lt;head&gt;
@@ -192,7 +79,7 @@ to obtain timing data related to the navigation of the document, resources on th
     &lt;script&gt;
        function init()
        {
-            performance.mark("startWork"); // see <a href='#UserTiming'>[User Timing]</a>
+            performance.mark("startWork"); // see [[User Timing]]
             doWork(); // Some developer code
             performance.mark("endWork");
 
@@ -213,272 +100,78 @@ to obtain timing data related to the navigation of the document, resources on th
     &lt;/script&gt;
   &lt;/body&gt;
 &lt;/html&gt;
-</pre>
-</div>
+    </pre>
+  </section>
 
-<h2 id="conformance-requirements"><span class="secno">2 </span>Conformance
-requirements</h2>
+  <section>
+    <h2>Terminology</h2>
+    <p>The construction "a `Foo` object", where `Foo` is actually an interface, is sometimes used instead of the more accurate "an object implementing the interface Foo".</p>
 
-<p>All diagrams, examples, and notes in this specification are non-normative,
-as are all sections explicitly marked non-normative. Everything else in this
-specification is normative. </p>
+    <p>Throughout this work, all time values are measured in milliseconds since the start of navigation of the document. For example, the start of navigation of the document occurs at time 0. The term <dfn>current time</dfn> refers to the number of milliseconds since the start of navigation of the document until the current moment in time. This definition of time is based on [[HR-TIME]] and is different from the definition of time used in the [[NAVIGATION-TIMING]], where time is measured in milliseconds since midnight of January 1, 1970 (UTC).
+  </section>
 
-<p>The key words "MUST", "MUST NOT", "REQUIRED", "SHOULD", "SHOULD NOT",
-"RECOMMENDED", "MAY", and "OPTIONAL" in the normative parts of this document
-are to be interpreted as described in <a href="#rfc2119">RFC 2119</a>.
-For readability, these words do not appear in all uppercase letters in this specification.</p>
+  <section>
+    <h2>Performance Timeline</h2>
 
-<p>Requirements phrased in the imperative as part of algorithms (such as
-"strip any leading space characters" or "return false and abort these steps")
-are to be interpreted with the meaning of the key word ("must", "should",
-"may", etc) used in introducing the algorithm. </p>
+    <section>
+      <h2>The <dfn>Performance Timeline</dfn></h2>
 
-<p>Some conformance requirements are phrased as requirements on attributes,
-methods or objects. Such requirements are to be interpreted as requirements
-on user agents. </p>
+      <p>All interfaces that participate in the <a>Performance Timeline</a> must adhere to the following rules:</p>
 
-<p>Conformance requirements phrased as algorithms or specific steps may be
-implemented in any manner, so long as the end result is equivalent. (In
-particular, the algorithms defined in this specification are intended to be
-easy to follow, and not intended to be performant.) </p>
+      <ul>
+        <li>MUST extend the <a>PerformanceEntry</a> interface</li>
+        <li>MUST be supported by the <a href="#widl-Performance-getEntries-PerformanceEntryList">getEntries</a>, <a href="#widl-Performance-getEntriesByType-PerformanceEntryList">getEntriesByType</a>, and <a href="#widl-Performance-getEntriesByName-PerformanceEntryList">getEntriesByName</a> methods</li>
+        <li>SHOULD surface new performance metrics in a timely manner</li>
+      </ul>
 
-    <p>The IDL fragments in this specification must be interpreted as
-    required for conforming IDL fragments, as described in the Web IDL
-    specification. <a href="#WebIDL">[Web IDL]</a></p>
+      <p>The user agent is NOT REQUIRED to provide synchronous access to new performance metrics. The user agent MAY delay reporting the metric to avoid performance bottlenecks; the application should not rely on synchronous access to performance metrics.</p>
+    </section>
 
-<h2 id="terminology"><span class="secno">3 </span>Terminology</h2>
+    <section>
+      <h2>The <dfn>PerformanceEntry</dfn> interface</h2>
 
-<p>The construction "a <code title="">Foo</code> object", where <code
-title="">Foo</code> is actually an interface, is sometimes used instead of
-the more accurate "an object implementing the interface <code
-title="">Foo</code>". </p>
+      <dl title='interface PerformanceEntry' class='idl'>
+        <dt>readonly attribute DOMString name</dt>
+        <dd>The attribute MUST return the identifier for this <a>PerformanceEntry</a> object. This identifier does not have to be unique.</dd>
+        <dt>readonly attribute DOMString entryType</dt>
+        <dd>This attribute MUST return a <a href="http://www.w3.org/TR/WebIDL/#idl-DOMString">DOMString</a> that describes the type of the interface represented by this <a>PerformanceEntry</a> object.</dd>
+        <dt>readonly attribute DOMString startTime</dt>
+        <dd>The attribute MUST return a <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp">DOMHighResTimeStamp</a> that contains the time value of the first recorded timestamp of this performance metric.</dd>
+        <dt>readonly attribute DOMString duration</dt>
+        <dd>The attribute MUST return a <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp">DOMHighResTimeStamp</a> that contains the time value of the duration of the entire event being recorded by this <a>PerformanceEntry</a>. Typically, this would be the time difference between the last recorded timestamp and the first recorded timestamp of this <a>PerformanceEntry</a>. If the duration concept doesn't apply, a performance metric may choose to return a `duration` of 0.</dd>
+        <dt>serializer = { attribute }</dt>
+      </dl>
 
-<p>
-  Throughout this work, all time values are measured in milliseconds since the start of
-  navigation of the document. For example, the start of navigation of the document
-  occurs at time 0. The term <i>current time</i> refers to the number of milliseconds
-  since the start of navigation of the document until the current moment in time.
-  This definition of time is based on the High Resolution Time specification
-  [<a href="http://www.w3.org/TR/hr-time/">High Resolution Time</a>] and is different
-  from the definition of time used in the Navigation Timing specification
-  [<a href="http://www.w3.org/TR/navigation-timing/">Navigation Timing</a>],
-  where time is measured in milliseconds since midnight of January 1, 1970 (UTC).
-</p>
+      <p class="note">The <a href="http://www.w3.org/wiki/Web_Performance/EntryType">Web Performance/entryType</a> wiki page lists all of the known <a href="#widl-PerformanceEntry-entryType">entryType</a> values.</p>
+    </section>
 
-<h2 id="sec-navigation-timing"><span class="secno">4 </span>Performance Timeline</h2>
+    <section>
+      <h2>Extensions to the Performance interface</h2>
 
-<h3 id="sec-performance-timeline"><span class="secno">4.1 </span> The Performance Timeline</h3>
-<p>
-	All interfaces that participate in the <a href="#sec-performance-timeline">Performance Timeline</a>, such as the
-	<a href="http://www.w3.org/TR/resource-timing/#performanceresourcetiming"><code>PerformanceResourceTiming</code></a> <a href='#ResourceTiming'>[Resource Timing]</a>,
-	<a href="http://www.w3.org/TR/user-timing/#performancemark"><code>PerformanceMark</code></a>, and
-	<a href="http://www.w3.org/TR/user-timing/#performancemeasure"><code>PerformanceMeasure</code></a>  <a href='#UserTiming'>[User Timing]</a> interfaces,
-	<span class='rfc2119'>must</span> adhere to the following rules:
-</p>
+      <dl class="idl" title="typedef sequence PerformanceEntry PerformanceEntryList"></dl>
 
-<ul>
-	<li><Span Class='Rfc2119'>MUST</Span> extend the <a href="#performanceentry"><code>PerformanceEntry</code></a> interface</li>
-	<li><Span Class='Rfc2119'>MUST</Span> be supported by the
-		<a href="#dom-performance-getentries"><code>getEntries</code></a>,
-		<a href="#dom-performance-getentriesbytype"><code>getEntriesByType</code></a>, and
-		<a href="#dom-performance-getentriesbyname"><code>getEntriesByName</code></a> methods
-	</li>
-  <li><Span Class='Rfc2119'>SHOULD</Span> surface new performance metrics in a timely manner</li>
-</ul>
+      <dl title='partial interface Performance' class='idl'>
+        <dt>PerformanceEntryList getEntries()</dt>
+        <dd>This method returns a <a>PerformanceEntryList</a> object that contains a copy of all <a>PerformanceEntry</a> objects in chronological order with respect to <a href="#widl-PerformanceEntry-startTime">startTime</a>.</dd>
 
-<div class="note">
-<div class="noteHeader">Note</div>
-  <p>
-    The user agent is not required to provide synchronous access to new performance metrics - i.e. the user agent may delay reporting the metric to avoid performance bottlenecks; the application should not rely on synchronous access to performance metrics - e.g. try to process a metric immediately after invoking an operation that triggers it.
-  </p>
-</div>
+        <dt>PerformanceEntryList getEntriesByType(DOMString entryType)</dt>
+        <dd>This method returns a <a>PerformanceEntryList</a> object that contains a copy of all <a>PerformanceEntry</a> objects, in chronological order with respect to <a href="#widl-PerformanceEntry-startTime">startTime</a>, that have the same value for the <a href="#widl-PerformanceEntry-entryType">entryType</a> attribute of <a>PerformanceEntry</a> as the <a href="#widl-PerformanceEntry-entryType">entryType</a> parameter. If no such <a>PerformanceEntry</a> objects exist, the <a>PerformanceEntryList</a> must be empty.</dd>
 
-<h3 id="sec-PerformanceEntry-interface"><span class="secno">4.2 </span> The <a href="#performanceentry"><code>PerformanceEntry</code></a>
-interface</h3>
-<pre class="idl">interface <dfn id="performanceentry">PerformanceEntry</dfn> {
-  readonly attribute <a href='http://www.w3.org/TR/WebIDL/#idl-DOMString'>DOMString</a> <a href='#dom-performanceentry-name' title='name'>name</a>;
-  readonly attribute <a href='http://www.w3.org/TR/WebIDL/#idl-DOMString'>DOMString</a> <a href='#dom-performanceentry-entrytype' title='entryType'>entryType</a>;
-  readonly attribute <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp">DOMHighResTimeStamp</a> <a href='#dom-performanceentry-starttime' title='startTime'>startTime</a>;
-  readonly attribute <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp">DOMHighResTimeStamp</a> <a href='#dom-performanceentry-duration' title='duration'>duration</a>;
+        <dt>PerformanceEntryList getEntriesByName(DOMString name, optional DOMString entryType)</dt>
+        <dd>This method returns a <a>PerformanceEntryList</a> object that contains a copy of <a>PerformanceEntry</a> objects, in chronological order with respect to <a href="#widl-PerformanceEntry-startTime">startTime</a>, that have the same value for the <a href="#widl-PerformanceEntry-name">name</a> attribute of <a>PerformanceEntry</a> as the <a href="#widl-PerformanceEntry-name">name</a> parameter and, if specified, have the same value for the <a href="#widl-PerformanceEntry-entryType">entryType</a> attribute of <a>PerformanceEntry</a> as the <a href="#widl-PerformanceEntry-entryType">entryType</a> parameter. If no such <a>PerformanceEntry</a> objects exist, the <a>PerformanceEntryList</a> must be empty.</dd>
+      </dl>
+    </section>
 
-  serializer = { attribute };
-};
-</pre>
+    <section>
+      <h2>Vendor Extensions</h2>
 
-<h4 id="dom-performanceentry-name"><code>name</code> attribute</h4>
-<p>
-	The <code>name</code> attribute <span class='rfc2119'>must</span> return the identifier for this <a href="#performanceentry"><code>PerformanceEntry</code></a> object. This
-	identifier does not have to be unique.
-</p>
+      <p>If a vendor-specific proprietary user agent extension is needed to create experimental <a>PerformanceEntry</a> objects, on getting the <a href="#widl-PerformanceEntry-entryType">entryType</a> IDL attribute, vendors MUST return a `DOMString` that uses the following convention:</p>
 
-<h4 id="dom-performanceentry-entrytype"><code>entryType</code> attribute</h4>
-<p>
-	The <code>entryType</code> attribute <span class='rfc2119'>must</span> return a <a href='http://www.w3.org/TR/WebIDL/#idl-DOMString'><code>DOMString</code></a> that describes the <i>type</i> of the interface represented by this <a href="#performanceentry"><code>PerformanceEntry</code></a> object.
-</p>
+      <pre>[vendorPrefix]-[entryType]</pre>
 
-<div class="note">
-<div class="noteHeader">Note</div>
-  <p>
-    The <a href="http://www.w3.org/wiki/Web_Performance/EntryType">Web Performance/entryType</a> wiki page lists all of the known <code>entryType</code> values.
-  </p>
-</div>
+      <p>Where, `[vendorPrefix]` is a non-capitalized name that identifies the vendor, `[entryType]` is a non-capitalized name given to the type of the interface represented by this <a>PerformanceEntry</a> object, and the above names are in ASCII.</p>
+    </section>
+  </section>
 
-<h4 id="dom-performanceentry-starttime"><code>startTime</code> attribute</h4>
-<p>
-	The <code>startTime</code> attribute <span class='rfc2119'>must</span> return a <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp"><code>DOMHighResTimeStamp</code></a>
-	that contains the time value of the first recorded timestamp of this performance metric.
-<p>
-
-<h4 id="dom-performanceentry-duration"><code>duration</code> attribute</h4>
-<p>
-	The <code>duration</code> attribute <span class='rfc2119'>must</span> return a <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp"><code>DOMHighResTimeStamp</code></a>
-	that contains the time value of the duration of the entire event being recorded by this <a href="#performanceentry"><code>PerformanceEntry</code></a>. Typically, this would be the
-	time difference between the last recorded timestamp and the first recorded timestamp of this <a href="#performanceentry"><code>PerformanceEntry</code></a>. A performance metric may choose
-	to return a <code>duration</code> of 0, if the duration concept doesn't apply.
-<p>
-
-<h3 id="sec-window.performance-attribute"><span class="secno">4.3 </span> Extensions to the <code id="dom-window-performance">Performance</code> interface</h3>
-<pre class="idl">partial interface <dfn id="performance">Performance</dfn> {
-  <a href="#performanceentrylist">PerformanceEntryList</a> <a href="#dom-performance-getentries">getEntries</a>();
-  <a href="#performanceentrylist">PerformanceEntryList</a> <a href="#dom-performance-getentriesbytype">getEntriesByType</a>(DOMString entryType);
-  <a href="#performanceentrylist">PerformanceEntryList</a> <a href="#dom-performance-getentriesbyname">getEntriesByName</a>(DOMString name, optional DOMString entryType);
-};
-
-typedef sequence &lt;PerformanceEntry&gt; <b><dfn id='performanceentrylist'>PerformanceEntryList</dfn></b>;
-
-</pre>
-
-<p>
-The <a href="http://www.w3.org/TR/navigation-timing/#dom-window-performance"><code>window.performance</code></a> attribute provides a hosting area for performance measurement related attributes and methods using the <a href='http://www.w3.org/TR/navigation-timing/#performance'><code>Performance</code></a> interface <a href='#NavigationTiming'>[Navigation Timing]</a>.
-</p>
-
-<div class="methods">
-    <h4 id="dom-performance-getentries"><code>getEntries</code> method</h4>
-	<p>The <code>getEntries</code> method returns a
-		<a href="#performanceentrylist"><code>PerformanceEntryList</code></a> object that contains a copy of all <a href="#performanceentry"><code>PerformanceEntry</code></a> objects in chronological order with respect to <a href="#dom-performanceentry-starttime">startTime</a>.
-    </p>
-
-		<div class="parameters">
-				<p><b>No parameters</b></p>
-				<p><b>Return value</b></p>
-				A <a href="#performanceentrylist"><code>PerformanceEntryList</code></a> object.
-				<p><b>No exceptions</b></p>
-		</div>
-</div>
-
-
-<div class="methods">
-    <h4 id="dom-performance-getentriesbytype"><code>getEntriesByType</code> method</h4>
-	<p>The <code>getEntriesByType</code> method returns a
-		<a href="#performanceentrylist"><code>PerformanceEntryList</code></a> object that contains a copy of all <a href="#performanceentry"><code>PerformanceEntry</code></a> objects, in chronological order with respect to <a href="#dom-performanceentry-starttime">startTime</a>,
-		that have the same value for the <code>entryType</code> attribute of <a href="#performanceentry"><code>PerformanceEntry</code></a> as the <code>entryType</code> parameter.
-    </p>
-
-		<div class="parameters">
-				<p><b>Parameter</b></p>
-					<p><a href='http://www.w3.org/TR/WebIDL/#idl-DOMString'><code>DOMString</code></a> <code>entryType</code></p>
-                    <p>
-                        A <a href="#performanceentrylist"><code>PerformanceEntryList</code></a> object that contains a copy of <a href="#performanceentry"><code>PerformanceEntry</code></a> objects
-				        that have the same value for the <code>entryType</code> attribute of <a href="#performanceentry"><code>PerformanceEntry</code></a> as the <code>entryType</code> parameter.
-				        If no such <a href="#performanceentry"><code>PerformanceEntry</code></a> objects exist, the <a href="#performanceentrylist"><code>PerformanceEntryList</code></a>
-				        <span class='rfc2119'>must</span> be empty.
-		            </p>
-				<p><b>Return value</b></p>
-		        A <a href="#performanceentrylist"><code>PerformanceEntryList</code></a> object.
-				<p><b>No exceptions</b></p>
-		</div>
-</div>
-
-<div class="methods">
-    <h4 id="dom-performance-getentriesbyname"><code>getEntriesByName</code> method</h4>
-	<p>
-		The <code>getEntriesByName</code> method returns a
-		<a href="#performanceentrylist"><code>PerformanceEntryList</code></a> object that contains a copy of <a href="#performanceentry"><code>PerformanceEntry</code></a> objects, in chronological order with respect to <a href="#dom-performanceentry-starttime">startTime</a>,
-		that have the same value for the <code>name</code> attribute of <a href="#performanceentry"><code>PerformanceEntry</code></a> as the <code>name</code> parameter
-		and, if specified, have the same value for the <code>entryType</code> attribute of <a href="#performanceentry"><code>PerformanceEntry</code></a> as the <code>entryType</code> parameter.
-    </p>
-		<div class="parameters">
-				<p><b>Parameter</b></p>
-					<p><a href='http://www.w3.org/TR/WebIDL/#idl-DOMString'><code>DOMString</code></a> <code>name</code></p>
-					<p>
-						The <a href="#performanceentrylist"><code>PerformanceEntryList</code></a> object that contains a copy of <a href="#performanceentry"><code>PerformanceEntry</code></a> objects
-						that have the same value for the <code>name</code> attribute of <a href="#performanceentry"><code>PerformanceEntry</code></a> as the <code>name</code> parameter.
-						If no such <a href="#performanceentry"><code>PerformanceEntry</code></a> objects exist, the <a href="#performanceentrylist"><code>PerformanceEntryList</code></a> <span class='rfc2119'>must</span> be empty.
-					</p>
-					<p><a href='http://www.w3.org/TR/WebIDL/#idl-DOMString'><code>DOMString</code></a> <code>entryType</code></p>
-					<p>
-						The <a href="#performanceentrylist"><code>PerformanceEntryList</code></a> object that only contains a copy of <a href="#performanceentry"><code>PerformanceEntry</code></a> objects
-						that have the same value for the <code>entryType</code> attribute of <a href="#performanceentry"><code>PerformanceEntry</code></a> as the <code>entryType</code> parameter
-						and have the same value for the <code>name</code> attribute of <a href="#performanceentry"><code>PerformanceEntry</code></a> as the <code>name</code> parameter.
-						If no such <a href="#performanceentry"><code>PerformanceEntry</code></a> objects exist, the <a href="#performanceentrylist"><code>PerformanceEntryList</code></a>
-						<span class='rfc2119'>must</span> be empty.
-					</p>
-				<p><b>Return value</b></p>
-				A <a href="#performanceentrylist"><code>PerformanceEntryList</code></a> object.
-				<p><b>No exceptions</b></p>
-		</div>
-</div>
-
-<h3 id="sec-vendor-extensions">4.4 Vendor Extensions</h3>
-
-<p>
-  If a vendor-specific proprietary user agent extension is needed to create experimental
-  <a href="#performanceentry"><code>PerformanceEntry</code></a> objects, on getting the
-  <a href="#dom-performanceentry-entrytype"><code>entryType</code></a> IDL attribute, vendors MUST return a DOMString that uses the following convention:
-</p>
-
-<p><code>[vendorprefix]-[entrytype]</code></p>
-
-<p>Where,</p>
-<ul>
-  <li>
-    <code>[vendorprefix]</code> is a non-capitalized name that identifies the vendor,
-  </li>
-  <li>
-    <code>[entrytype]</code> is a non-capitalized name given to the <i>type</i> of the interface
-    represented by this <a href="#performanceentry"><code>PerformanceEntry</code></a> object,
-  </li>
-  <li>
-    and the above names are in ASCII.
-  </li>
-</ul>
-
-
-<h2 id="references"><span class="secno">5 </span>References</h2>
-
-<h2 id="normative-references"><span class="secno">5.1 </span>Normative References</h2>
-
-<dl id='references-list'>
-<dt><a id='rfc2119'>[IETF RFC 2119]</a></dt>
-<dd>
- <cite><a href='http://www.ietf.org/rfc/rfc2119.txt'>Key words for use in RFCs to Indicate Requirement Levels</a></cite>, Scott Bradner, Author. Internet Engineering Task Force, March 1997. Available at http://www.ietf.org/rfc/rfc2119.txt.
-</dd>
-   <dt>[<a id="NavigationTiming">Navigation Timing</a>]</dt>
-   <dd><cite><a href='http://www.w3.org/TR/2012/REC-navigation-timing-20121217/'>Navigation Timing</a></cite>, Zhiheng Wang, Editor. W3C Recommendation, World Wide Web Consortium, December 2012. This version of the Navigation Timing specification is available from http://www.w3.org/TR/2012/REC-navigation-timing-20121217/. The <a href='http://www.w3.org/TR/navigation-timing/'>latest version of Navigation Timing</a> is available at http://www.w3.org/TR/navigation-timing/.</dd>
-
-   <dt>[<a id="HighResolutionTime">High Resolution Time</a>]</dt>
-   <dd><cite><a href='http://www.w3.org/TR/2012/REC-hr-time-20121217/'>High Resolution Time</a></cite>, Jatinder Mann, Editor. W3C Recommendation, World Wide Web Consortium, December 2012. This version of the High Resolution Time specification is available from http://www.w3.org/TR/2012/REC-hr-time-20121217/. The <a href='http://www.w3.org/TR/hr-time/'>latest version of High Resolution Time</a> is available at http://www.w3.org/TR/hr-time/.</dd>
-
-   <dt>[<a id="WebIDL">Web IDL</a>]</dt>
-   <dd><cite><a href='http://www.w3.org/TR/2012/CR-WebIDL-20120419/'>Web IDL</a></cite>, Cameron McCormack, Editor. World Wide Web Consortium, April 2012. This version of the Web IDL specification is available from http://www.w3.org/TR/2012/CR-WebIDL-20120419/. The <a href='http://www.w3.org/TR/WebIDL/'>latest version of Web IDL</a> is available at http://www.w3.org/TR/WebIDL/.</dd>
-
-</dl>
-
-<h2 id="informative-references"><span class="secno">5.1 </span>Informative References</h2>
-
-<dl id='informative-references-list'>
-   <dt>[<a id="UserTiming">User Timing</a>]</dt>
-   <dd><cite><a href='http://www.w3.org/TR/2012/CR-user-timing-20120726/'>User Timing</a></cite>, J. Mann, Z. Wang, et al. Editors. World Wide Web Consortium, July 2012. This version of the User Timing specification is available from http://www.w3.org/TR/2012/CR-user-timing-20120726/. The <a href='http://www.w3.org/TR/user-timing/'>latest version of User Timing</a> is available at http://www.w3.org/TR/user-timing/.</dd>
-   <dt>[<a id="ResourceTiming">Resource Timing</a>]</dt>
-   <dd><cite><a href='http://www.w3.org/TR/2012/CR-resource-timing-20120522/'>Resource Timing</a></cite>, J. Mann, Z. Wang, et al. Editors. World Wide Web Consortium, May 2012. This version of the Resource Timing specification is available from http://www.w3.org/TR/2012/CR-resource-timing-20120522/. The <a href='http://www.w3.org/TR/user-timing/'>latest version of Resource Timing</a> is available at http://www.w3.org/TR/user-timing/.</dd>
-
-</dl>
-
-
-
-<h2 class="no-num" id="acknowledgements">Acknowledgements</h2>
-
-<p>We would like to offer our sincere thanks to all the people that we have been
-in touch with regarding this draft for their reviews and feedback.</p>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <title>Performance Timeline</title>
   <meta charset='utf-8'>
-  <script src='//www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
+  <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
   <script class='remove'>
   var respecConfig = {
     shortName: "performance-timeline",
@@ -53,7 +53,7 @@
 
 <body>
   <section id='abstract'>
-    <p>This specification defines a unified interface to store and retrieve high resolution performance metric data.</p>
+    <p>This specification extends the High Resolution Time specification [[!HR-TIME-2]] by providing methods to store and retrieve high resolution performance metric data.</p>
   </section>
 
   <section id='sotd'>
@@ -65,7 +65,7 @@
 
     <p>Accurately measuring performance characteristics of web applications is an important aspect of making web applications faster. This specification defines the necessary <a>Performance Timeline</a> primitives that enable web developers to access, instrument, and retrieve various performance metrics from the full lifecycle of a web application.</p>
 
-    <p>[[NAVIGATION-TIMING]], [[RESOURCE-TIMING]], and [[USER-TIMING]] are examples of specifications that define timing information related to the navigation of the document, resources on the page, and developer scripts, respectively. Together these and other performance interfaces define performance metrics that describe the <a>Performance Timeline</a> of a web application. For example, the following script shows how a developer can access the <a>Performance Timeline</a> to obtain performance metrics related to the navigation of the document, resources on the page, and developer scripts:</p>
+    <p>[[NAVIGATION-TIMING-2]], [[RESOURCE-TIMING]], and [[USER-TIMING]] are examples of specifications that define timing information related to the navigation of the document, resources on the page, and developer scripts, respectively. Together these and other performance interfaces define performance metrics that describe the <a>Performance Timeline</a> of a web application. For example, the following script shows how a developer can access the <a>Performance Timeline</a> to obtain performance metrics related to the navigation of the document, resources on the page, and developer scripts:</p>
 
     <pre class="highlight example">
 &lt;!doctype html&gt;
@@ -169,39 +169,13 @@
       </section>
 
       <section>
-        <h2>The <dfn>Performance</dfn> interface</h2>
+        <h2>Extensions to the <dfn>Performance</dfn> interface</h2>
 
-        <p>The <a>Performance</a> interface hosts performance related attributes and methods used to retrieve the performance metric data from the <a>Performance Timeline</a>.</p>
+        <p>This extends the <a href='http://www.w3.org/TR/hr-time/#idl-def-Performance'>Performance</a> interface [[!HR-TIME-2]] and hosts performance related attributes and methods used to retrieve the performance metric data from the <a>Performance Timeline</a>.</p>
 
-        <dl title='dictionary FilterOptions' class='idl'>
-          <dt>DOMString name</dt>
-          <dd><a href="#widl-PerformanceEntry-name">name</a> of `PerformanceEntry` object.</dd>
-          <dt>DOMString entryType</dt>
-          <dd><a href="#widl-PerformanceEntry-type">entryType</a> of `PerformanceEntry` object.</dd>
-          <dt>DOMString initiatorType</dt>
-          <dd><a href="http://www.w3.org/TR/resource-timing/#widl-PerformanceResourceTiming-initiatorType">initiatorType</a> of `PerformanceEntry` object.</dd>
-        </dl>
-
-        <dl title='[Exposed=(Window,Worker)] interface Performance : EventTarget' class='idl'>
-          <dt>PerformanceEntryList getEntries(optional FilterOptions filter)</dt>
-          <dd>
-            <p>This method returns a <a>PerformanceEntryList</a> object that contains a list of <a>PerformanceEntry</a> objects, sorted in chronological order with respect to <a href="#widl-PerformanceEntry-startTime">startTime</a>, that match the following criteria:</p>
-
-            <ol>
-              <li>Let the <dfn>list of entry objects</dfn> be the empty <a>PerformanceEntryList</a>.</li>
-              <li> Let the <dfn>set of filter properties</dfn> be a set of pairs where the first element is the _name_ of a <a href="http://www.w3.org/TR/WebIDL/#dfn-dictionary-member">dictionary member</a> of `filter` that is present and the second element is the _value_ of that <a href="http://www.w3.org/TR/WebIDL/#dfn-dictionary-member">dictionary member</a>.</li>
-              <li>For each available <a>PerformanceEntry</a> object (<dfn>entryObject</dfn>), in chronological order with respect to <a href="#widl-PerformanceEntry-startTime">startTime</a>:</li>
-                <ol>
-                <li>For each _name_ and _value_ pair in <a>set of filter properties</a>:</li>
-                  <ol>
-                  <li>If the <a>entryObject</a> does not contain an attribute whose name matches _name_, go to next <a>entryObject</a>.</li>
-                  <li>Otherwise, if the <a>entryObject</a> contains an attribute whose name matches _name_, and its value does not match _value_, go to next <a>entryObject</a>.</li>
-                  </ol>
-                <li>Add <a>entryObject</a> to the <a>list of entry objects</a>.</li>
-                </ol>
-              <li>Return the <a>list of entry objects</a>.</li>
-            </ol>
-          </dd>
+        <dl title='partial interface Performance' class='idl'>
+          <dt>PerformanceEntryList getEntries()</dt>
+          <dd>This method returns a <a>PerformanceEntryList</a> object that contains a copy of all <a>PerformanceEntry</a> objects in chronological order with respect to <a href="#widl-PerformanceEntry-startTime">startTime</a>.</dd>
 
           <dt>PerformanceEntryList getEntriesByType(DOMString entryType)</dt>
           <dd>This method returns a <a>PerformanceEntryList</a> object returned by `getEntries({'entryType': entryType})`.</dd>

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
 
 <body>
   <section id='abstract'>
-    <p>This specification defines a unified interface to store and retrieve high resolution performance metric data.</p>
+    <p>This specification extends the High Resolution Time specification [[!HR-TIME-2]] by providing methods to store and retrieve high resolution performance metric data.</p>
   </section>
 
   <section id='sotd'>
@@ -65,7 +65,7 @@
 
     <p>Accurately measuring performance characteristics of web applications is an important aspect of making web applications faster. This specification defines the necessary <a>Performance Timeline</a> primitives that enable web developers to access, instrument, and retrieve various performance metrics from the full lifecycle of a web application.</p>
 
-    <p>[[NAVIGATION-TIMING]], [[RESOURCE-TIMING]], and [[USER-TIMING]] are examples of specifications that define timing information related to the navigation of the document, resources on the page, and developer scripts, respectively. Together these and other performance interfaces define performance metrics that describe the <a>Performance Timeline</a> of a web application. For example, the following script shows how a developer can access the <a>Performance Timeline</a> to obtain performance metrics related to the navigation of the document, resources on the page, and developer scripts:</p>
+    <p>[[NAVIGATION-TIMING-2]], [[RESOURCE-TIMING]], and [[USER-TIMING]] are examples of specifications that define timing information related to the navigation of the document, resources on the page, and developer scripts, respectively. Together these and other performance interfaces define performance metrics that describe the <a>Performance Timeline</a> of a web application. For example, the following script shows how a developer can access the <a>Performance Timeline</a> to obtain performance metrics related to the navigation of the document, resources on the page, and developer scripts:</p>
 
     <pre class="highlight example">
 &lt;!doctype html&gt;

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <title>Performance Timeline</title>
+  <title>Performance Timeline Level 2</title>
   <meta charset='utf-8'>
   <script src='//www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
   <script class='remove'>

--- a/index.html
+++ b/index.html
@@ -215,17 +215,6 @@
         </dl>
 
         <dl class='idl' title='typedef sequence<PerformanceEntry> PerformanceEntryList'></dl>
-
-        <dl class='idl' title='[NoInterfaceObject, Exposed=(Window,Worker)] interface GlobalPerformance'>
-        <dt>[Replaceable] readonly attribute Performance performance</dt>
-        <dd>
-        <p>This attribute allows access to performance related attributes and methods.</p>
-        </dd>
-        </dl>
-        <pre class='idl'>
-        Window implements GlobalPerformance;
-        WorkerGlobalScope implements GlobalPerformance;
-        </pre>
       </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
   &lt;body&gt;
     &lt;img id="image0" src="http://www.w3.org/Icons/w3c_main.png" /&gt;
     &lt;script&gt;
-    var observer = new PerformanceObserver(function(list) {
+    var observer = window.performance.createObserver(function(list) {
       var doneObservingEvents = false;
       var perfEntries = list.getEntries();
       for (var i = 0; i &lt; perfEntries.length; i++)
@@ -221,39 +221,43 @@
       <h2>The <dfn>Performance Observer</dfn> interface</h2>
 
       <p>The <a>PerformanceObserver</a> interface can be used to observe the <a>Performance Timeline</a> and be notified of new performance entries as they are recorded by the user agent. A <dfn>registered performance observer</dfn> consists of an observer (a <a>PerformanceObserver</a> object) and options (a <a>PerformanceObserverInit</a> dictionary).</p>
+      <section>
+        <h2>Extensions to the <a>Performance</a> interface</h2>
+        <dl title='callback PerformanceObserverCallback = void (PerformanceObserverEntryList entries, PerformanceObserver observer)' class='idl'></dl>
 
-      <dl title='callback PerformanceObserverCallback = void (PerformanceObserverEntryList entries, PerformanceObserver observer)' class='idl'></dl>
+        <dl title='partial interface Performance' class='idl'>
+          <dt>PerformanceObserver createPerformanceObserver(PerformanceObserverCallback callback) </dt>
+          <dd>This method creates a new <a>PerformanceObserver</a> and associates it with the <a>Performance Timeline</a></dd>
+        </dl>
+      </section>
+      <section>
+        <h2>The <dfn>PerformanceObserver</dfn> interface</h2>
+        <dl title='[Exposed=(Window,Worker)] interface PerformanceObserver' class='idl'>
 
-      <dl title='[Constructor(PerformanceObserverCallback callback), Exposed=(Window,Worker)] interface PerformanceObserver' class='idl'>
+          <dt>void observe(PerformanceObserverInit options)</dt>
+          <dd>This method instructs the user agent to <dfn>register the observer</dfn> and report any new performance entries based on the criteria given by _options_.
+            <dl title='dictionary PerformanceObserverInit' class='idl'>
+              <dt>required sequence&lt;DOMString&gt; typeFilter</dt>
+              <dd>
+                <p>A list of valid <a href="#widl-PerformanceEntry-entryType">entryType names</a> to be observed. The list MUST NOT be empty and types not recognized by the user agent MUST be ignored.</p>
 
-        <dt>void observe(PerformanceObserverInit options)</dt>
-        <dd>This method instructs the user agent to <dfn>register the observer</dfn> and report any new performance entries based on the criteria given by _options_.
-          <dl title='dictionary PerformanceObserverInit' class='idl'>
-            <dt>required sequence&lt;DOMString&gt; typeFilter</dt>
-            <dd>
-              <p>A list of valid <a href="#widl-PerformanceEntry-entryType">entryType names</a> to be observed. The list MUST NOT be empty and types not recognized by the user agent MUST be ignored.</p>
+                <p class="note">To keep the performance overhead to minimum the application should only subscribe to event types that it is interested in, and disconnect the observer once it no longer needs to observe the performance data. Filtering by name is not supported, as it would implicitly require a subscription for all event types &mdash; this is possible, but discouraged, as it will generate a significant volume of events.</p>
+              </dd>
+            </dl>
 
-              <p class="note">To keep the performance overhead to minimum the application should only subscribe to event types that it is interested in, and disconnect the observer once it no longer needs to observe the performance data. Filtering by name is not supported, as it would implicitly require a subscription for all event types &mdash; this is possible, but discouraged, as it will generate a significant volume of events.</p>
-            </dd>
-            <dt>Performance? target</dt>
-            <dd>
-              An optional <a>Performance Timeline</a> to observe. If this is _null_, the global `window.performance` at the time the <a>PerformanceObserver</a> was created will be used.
-            </dd>
-          </dl>
+            <p>The `observe(options)` method must run these steps:</p>
+            <ol>
+              <li>If _options'_ `typeFilter` attribute is not present, <a href="http://heycam.github.io/webidl/#dfn-throw">throw</a> a JavaScript `TypeError`.</li>
+              <li>Filter unsupported <a href="#widl-PerformanceEntry-entryType">entryType names</a> within the `typeFilter` sequence, and replace the `typeFilter` sequence with the new filtered sequence.</li>
+              <li>If the _options'_ `typeFilter` attribute is an empty sequence, <a href="http://heycam.github.io/webidl/#dfn-throw">throw</a> a JavaScript `TypeError`.</li>
+              <li>Add a new <a>registered performance observer</a> with the <a href="http://www.w3.org/TR/dom/#context-object">context object</a> as the <dfn>observer</dfn> and _options_ as the `options`.</li>
+            </ol>
+          </dd>
 
-          <p>The `observe(options)` method must run these steps:</p>
-          <ol>
-            <li>If _options'_ `typeFilter` attribute is not present, <a href="http://heycam.github.io/webidl/#dfn-throw">throw</a> a JavaScript `TypeError`.</li>
-            <li>Filter unsupported <a href="#widl-PerformanceEntry-entryType">entryType names</a> within the `typeFilter` sequence, and replace the `typeFilter` sequence with the new filtered sequence.</li>
-            <li>If the _options'_ `typeFilter` attribute is an empty sequence, <a href="http://heycam.github.io/webidl/#dfn-throw">throw</a> a JavaScript `TypeError`.</li>
-            <li>Add a new <a>registered performance observer</a> to the target <a>performance timeline</a> with the <a href="http://www.w3.org/TR/dom/#context-object">context object</a> as the <dfn>observer</dfn> and _options_ as the `options`.</li>
-          </ol>
-        </dd>
-
-        <dt>void disconnect()</dt>
-        <dd>This method must remove the <a>registered performance observer</a> from all <a>Performance Timeline</a>s for which the <a href="http://www.w3.org/TR/dom/#context-object">context object</a> is an <a>observer</a>.</dd>
-      </dl>
-
+          <dt>void disconnect()</dt>
+          <dd>This method must remove the <a>registered performance observer</a> from the <a>Performance Timeline</a> for which the <a href="http://www.w3.org/TR/dom/#context-object">context object</a> is an <a>observer</a>.</dd>
+        </dl>
+      </section>
       <section>
         <h2>The <dfn>PerformanceObserverEntryList</dfn> interface</h2>
 


### PR DESCRIPTION
PerformanceObserver.observe(options) should really be PerformanceObserver.observe(target, options) , where 'target' is a Performance.
The API is a little vague otherwise. 
Not sure if this means we want to introduce observer.disconnect(target) or just keep observer.disconnect() as a "disconnect all" function.