### PR TITLE
Observers observe user timing entries.

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,7 +365,7 @@ typedef sequence&lt;PerformanceEntry> PerformanceEntryList;</pre>
       <h2>The <dfn>PerformanceObserver</dfn> interface</h2>
       <p>The <a>PerformanceObserver</a> interface can be used to observe the
       <a>Performance Timeline</a> and be notified of new performance entries as
-      they are recorded by the user agent.</p>
+      they are recorded.</p>
       <p>Each <a>PerformanceObserver</a> has these associated concepts:</p>
       <ul>
         <li>A <dfn>callback</dfn> set on creation.</li>


### PR DESCRIPTION
The previous phrasing made it sound as though only performance timeline entries which the user agent is responsible for recording are observable. It might be better to make this more explicit than what I've proposed, but I think this is less confusing than what was there before.