### PR TITLE
Refactor, shuffle order, improve navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     }],
     wg: "Web Performance Working Group",
     wgURI: "https://www.w3.org/webperf/",
-    license: 'w3c-software-doc',
+    license: "w3c-software-doc",
     wgPublicList: "public-web-perf",
     subjectPrefix: "[Performance Timeline]",
     format: "markdown",
@@ -196,6 +196,212 @@
       <a>PerformanceEntry</a> objects. It is initially empty.
       </li>
     </ul>
+    <section data-dfn-for="Performance" data-link-for="Performance">
+      <h2>Extensions to the <a>Performance</a> interface</h2>
+      <p>This extends the <a>Performance</a> interface [[!HR-TIME-2]] and hosts
+      performance related attributes and methods used to retrieve the
+      performance metric data from the <a>Performance Timeline</a>.</p>
+      <pre class="idl">
+      partial interface Performance {
+        PerformanceEntryList getEntries ();
+        PerformanceEntryList getEntriesByType (DOMString type);
+        PerformanceEntryList getEntriesByName (DOMString name, optional DOMString type);
+      };
+      typedef sequence&lt;PerformanceEntry&gt; PerformanceEntryList;
+      </pre>
+      <p>The <dfn>PerformanceEntryList</dfn> represents a sequence of
+      <a>PerformanceEntry</a>, providing developers with all the convenience
+      methods found on JavaScript arrays.</p>
+      <section>
+        <h2><dfn>getEntries()</dfn> method</h2>
+        <p>Returns a <a>PerformanceEntryList</a> object returned by
+        <a href="#filter-buffer-by-name-and-type"></a> algorithm with
+        <var>buffer</var> set to <a>performance entry buffer</a>, and
+        <var>name</var> and <var>type</var> set to `null`.</p>
+      </section>
+      <section>
+        <h2><dfn>getEntriesByType()</dfn> method</h2>
+        <p>Returns a <a>PerformanceEntryList</a> object returned by
+        <a href="#filter-buffer-by-name-and-type"></a> algorithm with
+        <var>buffer</var> set to <a>performance entry buffer</a>,
+        <var>name</var> set to `null`, and <var>type</var> set
+        to `type`.</p>
+      </section>
+      <section>
+        <h2><dfn>getEntriesByName()</dfn> method</h2>
+        <p>Returns a <a>PerformanceEntryList</a> object returned by
+        <a href="#filter-buffer-by-name-and-type"></a> algorithm with
+        <var>buffer</var> set to <a>performance entry buffer</a>,
+        <var>name</var> set to `name`, and <var>type</var> set
+        to `null` if optional `entryType` is omitted, and <var>type</var> set
+        to `type` otherwise.</p>
+      </section>
+    </section>
+    <section data-dfn-for="PerformanceEntry" data-link-for="PerformanceEntry">
+      <h2>The <dfn>PerformanceEntry</dfn> interface</h2>
+      <p>The <a>PerformanceEntry</a> interface hosts the performance data of
+      various metrics.</p>
+      <pre class='idl'>
+      [Exposed=(Window,Worker)]
+      interface PerformanceEntry {
+        readonly    attribute DOMString           name;
+        readonly    attribute DOMString           entryType;
+        readonly    attribute DOMHighResTimeStamp startTime;
+        readonly    attribute DOMHighResTimeStamp duration;
+        serializer = {attribute};
+      };</pre>
+      <dl>
+        <dt><dfn>name</dfn></dt>
+        <dd>This attribute MUST return an identifier for this
+        <a>PerformanceEntry</a> object. This identifier does not have to be
+        unique.</dd>
+        <dt><dfn>entryType</dfn></dt>
+        <dd>This attribute MUST return the type of the
+        interface represented by this <a>PerformanceEntry</a> object.
+        <p class="note">Example `entryType` values defined by other
+        specifications include: <code>"mark"</code> and <code>"measure"</code>
+        [[USER-TIMING-2]], <code>"navigation"</code> [[NAVIGATION-TIMING-2]],
+        <code>"resource"</code> [[RESOURCE-TIMING-2]],
+        <!-- TODO: add long task spec reference -->
+         and <code>"longtask"</code>.</p></dd>
+        <dt><dfn>startTime</dfn></dt>
+        <dd>This attribute MUST return the time value of the
+        first recorded timestamp of this performance metric.</dd>
+        <dt><dfn>duration</dfn></dt>
+        <dd>This attribute MUST return the time value of the
+      duration of the entire event being recorded by this
+      <a>PerformanceEntry</a>. Typically, this would be the time difference
+      between the last recorded timestamp and the first recorded timestamp of
+      this <a>PerformanceEntry</a>. If the duration concept doesn't apply, a
+      performance metric may choose to return a `duration` of
+      <code>0</code>.</dd>
+      </dl>
+      <p>As a convenience for developers, instances of <a>PerformanceEntry</a>
+      include a <dfn>serializer</dfn>. When called, attributes are
+      <a data-cite="WEBIDL#dfn-convert-to-serialized-value">converted to
+      serialized values</a> as per [[!WEBIDL]].</p>
+    </section>
+    <section data-link-for="PerformanceObserver" data-dfn-for=
+    "PerformanceObserver">
+      <h2>The <dfn>PerformanceObserver</dfn> interface</h2>
+      <p>The <a>PerformanceObserver</a> interface can be used to observe the
+      <a>Performance Timeline</a> and be notified of new performance entries as
+      they are recorded.</p>
+      <p>Each <a>PerformanceObserver</a> has these associated concepts:</p>
+      <ul>
+        <li>A <dfn>PerformanceObserverCallback</dfn> set on creation.</li>
+        <li>A list of <a>PerformanceEntry</a> objects called the <dfn>observer
+        buffer</dfn> that is initially empty.
+        </li>
+      </ul>
+      <p>The `PerformanceObserver(callback)` constructor must create a new
+      <a>PerformanceObserver</a> object with <a>PerformanceObserverCallback</a>
+      set to <var>callback</var> and then return it.</p>
+      <p>A <dfn>registered performance observer</dfn> consists of an observer
+      (a <a>PerformanceObserver</a> object) and options (a
+      <a>PerformanceObserverInit</a> dictionary).</p>
+      <pre class="idl">
+      callback PerformanceObserverCallback = void (PerformanceObserverEntryList entries,
+                                                   PerformanceObserver observer);
+      [Constructor(PerformanceObserverCallback callback), Exposed=(Window,Worker)]
+      interface PerformanceObserver {
+        void observe (PerformanceObserverInit options);
+        void disconnect ();
+      };
+      </pre>
+      <p class="note">To keep the performance overhead to minimum the
+      application should only subscribe to event types that it is interested
+      in, and disconnect the observer once it no longer needs to observe the
+      performance data. Filtering by name is not supported, as it would
+      implicitly require a subscription for all event types — this is possible,
+      but discouraged, as it will generate a significant volume of events.</p>
+      <p>The <dfn>observe()</dfn> method instructs the user agent to
+      <dfn>register the observer</dfn> and must run these steps:</p>
+      <ol data-link-for="PerformanceObserverInit">
+        <li>If _options'_ <a>entryTypes</a> attribute is not present,
+        <a>throw</a> a JavaScript `TypeError`.
+        </li>
+        <li>Filter unsupported names within the `entryTypes` sequence, and
+        replace the `entryTypes` sequence with the new filtered sequence.</li>
+        <li>If the _options'_ <a>entryTypes</a> attribute is an empty sequence,
+        <a>throw</a> a JavaScript `TypeError`.
+        </li>
+        <li>If the list of <a>registered performance observer</a> objects
+        associated with the <a>ECMAScript global environment</a> of the
+        interface object's contains a <a>registered performance observer</a>
+        that is the <a>context object</a>, replace the <a>context object</a>'s
+        `options` with <var>options</var>.
+        </li>
+        <li>Otherwise, append a new <a>registered performance observer</a>
+        object to the list of <a>registered performance observer</a> objects
+        associated with the <a>ECMAScript global environment</a> of the
+        interface object, with the <a>context object</a> as `observer` and
+        <var>options</var> as the `options`.
+        </li>
+      </ol>
+      <section>
+        <h2><dfn>disconnect()</dfn> method</h2>
+        <p>The <a>disconnect()</a> method must remove the <a>context object</a>
+        from the list of <a>PerformanceObserver</a> objects associated with the
+        <a>ECMAScript global environment</a> of the interface object, and also
+        empty <a>context object</a>'s <a>observer buffer</a>.</p>
+      </section>
+      <section data-dfn-for="PerformanceObserverInit" data-link-for=
+      "PerformanceObserverInit">
+        <h2><dfn>PerformanceObserverInit</dfn> dictionary</h2>
+        <pre class="idl">
+        dictionary PerformanceObserverInit {
+          required sequence&lt;DOMString&gt; entryTypes;
+        };
+        </pre>
+        <dl>
+          <dt><dfn>entryTypes</dfn></dt>
+          <dd>A list of entry names to be observed. The list MUST NOT be empty
+          and types not recognized by the user agent MUST be ignored.</dd>
+        </dl>
+      </section>
+      <section data-dfn-for="PerformanceObserverEntryList" data-link-for=
+      "PerformanceObserverEntryList">
+        <h2><dfn>PerformanceObserverEntryList</dfn> interface</h2>
+        <pre class="idl">
+        [Exposed=(Window,Worker)]
+        interface PerformanceObserverEntryList {
+          PerformanceEntryList getEntries();
+          PerformanceEntryList getEntriesByType (DOMString type);
+          PerformanceEntryList getEntriesByName (DOMString name, optional DOMString type);
+        };
+        </pre>
+        <section>
+          <h2><dfn>getEntries()</dfn> method</h2>
+          <p>Returns a <a>PerformanceEntryList</a> object returned by
+          <a href="#filter-buffer-by-name-and-type"></a> algorithm with
+          <var>buffer</var> set to <a>observer buffer</a>, and
+          <var>name</var> and <var>type</var> set to `null`.</p>
+        </section>
+        <section>
+          <h2><dfn>getEntriesByType()</dfn> method</h2>
+          <p>Returns a <a>PerformanceEntryList</a> object returned by
+          <a href="#filter-buffer-by-name-and-type"></a> algorithm with
+          <var>buffer</var> set to <a>observer buffer</a>,
+          <var>name</var> set to `null`, and <var>type</var> set
+          to `type`.</p>
+        </section>
+        <section>
+          <h2><dfn>getEntriesByName()</dfn> method</h2>
+          <p>Returns a <a>PerformanceEntryList</a> object returned by
+          <a href="#filter-buffer-by-name-and-type"></a> algorithm with
+          <var>buffer</var> set to <a>observer buffer</a>,
+          <var>name</var> set to `name`, and <var>type</var> set
+          to `null` if optional `entryType` is omitted, and <var>type</var> set
+          to `type` otherwise.</p>
+        </section>
+      </section>
+    </section>
+  </section>
+  <section>
+    <h2>Processing</h2>
+    <section data-link-for="PerformanceObserver">
+    <h2>Queue a <code>PerformanceEntry</code></h2>
     <p>To <dfn>queue a PerformanceEntry</dfn> (<i>new entry</i>), run these
     steps:</p>
     <ol>
@@ -254,196 +460,21 @@
     <p>The <i>performance timeline</i> <a>task queue</a> is a low priority
     queue that, if possible, should be processed by the user agent during idle
     periods to minimize impact of performance monitoring code.</p>
-    <section data-dfn-for="PerformanceEntry" data-link-for="PerformanceEntry">
-      <h2>The <dfn>PerformanceEntry</dfn> interface</h2>
-      <p>The <a>PerformanceEntry</a> interface hosts the performance data of
-      various metrics.</p>
-      <pre class='idl'>
-      [Exposed=(Window,Worker)]
-      interface PerformanceEntry {
-        readonly    attribute DOMString           name;
-        readonly    attribute DOMString           entryType;
-        readonly    attribute DOMHighResTimeStamp startTime;
-        readonly    attribute DOMHighResTimeStamp duration;
-        serializer = {attribute};
-      };</pre>
-      <p>The <dfn>name</dfn> attribute MUST return an identifier for this
-      <a>PerformanceEntry</a> object. This identifier does not have to be
-      unique.</p>
-      <p>The <dfn>entryType</dfn> attribute MUST return the type of the
-      interface represented by this <a>PerformanceEntry</a> object.</p>
-      <p class="note">Example `entryType` values defined by other
-      specifications include: <code>"mark"</code> and <code>"measure"</code>
-      [[USER-TIMING-2]], <code>"navigation"</code> [[NAVIGATION-TIMING-2]],
-      <code>"resource"</code> [[RESOURCE-TIMING-2]], 
-      <!-- TODO: add long task spec reference -->
-       and <code>"longtask"</code>.</p>
-      <p>The <dfn>startTime</dfn> attribute MUST return the time value of the
-      first recorded timestamp of this performance metric.</p>
-      <p>The <dfn>duration</dfn> attribute MUST return the time value of the
-      duration of the entire event being recorded by this
-      <a>PerformanceEntry</a>. Typically, this would be the time difference
-      between the last recorded timestamp and the first recorded timestamp of
-      this <a>PerformanceEntry</a>. If the duration concept doesn't apply, a
-      performance metric may choose to return a `duration` of
-      <code>0</code>.</p>
-      <p>As a convenience for developers, instances of <a>PerformanceEntry</a>
-      include a <dfn>serializer</dfn>. When called, attributes are
-      <a data-cite="WEBIDL#dfn-convert-to-serialized-value">converted to
-      serialized values</a> as per [[!WEBIDL]].</p>
     </section>
-    <section data-dfn-for="Performance" data-link-for="Performance">
-      <h2>Extensions to the <a>Performance</a> interface</h2>
-      <p>This extends the <a>Performance</a> interface [[!HR-TIME-2]] and hosts
-      performance related attributes and methods used to retrieve the
-      performance metric data from the <a>Performance Timeline</a>.</p>
-      <pre class="idl">
-      partial interface Performance {
-        PerformanceEntryList getEntries ();
-        PerformanceEntryList getEntriesByType (DOMString type);
-        PerformanceEntryList getEntriesByName (DOMString name, optional DOMString type);
-      };
-      typedef sequence&lt;PerformanceEntry&gt; PerformanceEntryList;
-      </pre>
-      <p>The <dfn>PerformanceEntryList</dfn> represents a sequence of
-      <a>PerformanceEntry</a>, providing developers with all the convenience
-      methods found on JavaScript arrays.</p>
-      <p>The <dfn>getEntries()</dfn> method returns a
-      <a>PerformanceEntryList</a> object returned by <a href=
-      "#filter-performance-entry-buffer-by-name-and-type"></a> algorithm with
-      <var>name</var> and <var>type</var> set to `null`.</p>
-      <p>The <dfn>getEntriesByType()</dfn> method returns a
-      <a>PerformanceEntryList</a> object returned by <a href=
-      "#filter-performance-entry-buffer-by-name-and-type"></a> algorithm with
-      <var>name</var> set to `null` and <var>type</var> set to `type`.</p>
-      <p>The <dfn>getEntriesByName()</dfn> method returns a
-      <a>PerformanceEntryList</a> object returned by <a href=
-      "#filter-performance-entry-buffer-by-name-and-type"></a> algorithm with
-      <var>name</var> set to `name` and <var>type</var> set to `null` if
-      optional `entryType` is omitted, and <var>type</var> set to `type`
-      otherwise.</p>
-    </section>
-    <section data-dfn-for="PerformanceObserverInit" data-link-for=
-    "PerformanceObserverInit">
-      <h2><dfn>PerformanceObserverInit</dfn> dictionary</h2>
-      <pre class="idl">
-      dictionary PerformanceObserverInit {
-        required sequence&lt;DOMString&gt; entryTypes;
-      };
-      </pre>
-      <dl>
-        <dt><dfn>entryTypes</dfn></dt>
-        <dd>A list of entry names to be observed. The list MUST NOT be empty
-        and types not recognized by the user agent MUST be ignored.</dd>
-      </dl>
-    </section>
-    <section data-link-for="PerformanceObserver" data-dfn-for=
-    "PerformanceObserver">
-      <h2><dfn>PerformanceObserver</dfn> interface</h2>
-      <p>The <a>PerformanceObserver</a> interface can be used to observe the
-      <a>Performance Timeline</a> and be notified of new performance entries as
-      they are recorded.</p>
-      <p>Each <a>PerformanceObserver</a> has these associated concepts:</p>
-      <ul>
-        <li>A <dfn>PerformanceObserverCallback</dfn> set on creation.</li>
-        <li>A list of <a>PerformanceEntry</a> objects called the <dfn>observer
-        buffer</dfn> that is initially empty.
-        </li>
-      </ul>
-      <p>The `PerformanceObserver(callback)` constructor must create a new
-      <a>PerformanceObserver</a> object with <a>PerformanceObserverCallback</a>
-      set to <var>callback</var> and then return it.</p>
-      <p>A <dfn>registered performance observer</dfn> consists of an observer
-      (a <a>PerformanceObserver</a> object) and options (a
-      <a>PerformanceObserverInit</a> dictionary).</p>
-      <pre class="idl">
-      callback PerformanceObserverCallback = void (PerformanceObserverEntryList entries,
-                                                   PerformanceObserver observer);
-      [Constructor(PerformanceObserverCallback callback), Exposed=(Window,Worker)]
-      interface PerformanceObserver {
-        void observe (PerformanceObserverInit options);
-        void disconnect ();
-      };
-      </pre>
-      <p class="note">To keep the performance overhead to minimum the
-      application should only subscribe to event types that it is interested
-      in, and disconnect the observer once it no longer needs to observe the
-      performance data. Filtering by name is not supported, as it would
-      implicitly require a subscription for all event types — this is possible,
-      but discouraged, as it will generate a significant volume of events.</p>
-      <p>The <dfn>observe()</dfn> method instructs the user agent to
-      <dfn>register the observer</dfn> and must run these steps:</p>
-      <ol data-link-for="PerformanceObserverInit">
-        <li>If _options'_ <a>entryTypes</a> attribute is not present,
-        <a>throw</a> a JavaScript `TypeError`.
-        </li>
-        <li>Filter unsupported names within the `entryTypes` sequence, and
-        replace the `entryTypes` sequence with the new filtered sequence.</li>
-        <li>If the _options'_ <a>entryTypes</a> attribute is an empty sequence,
-        <a>throw</a> a JavaScript `TypeError`.
-        </li>
-        <li>If the list of <a>registered performance observer</a> objects
-        associated with the <a>ECMAScript global environment</a> of the
-        interface object's contains a <a>registered performance observer</a>
-        that is the <a>context object</a>, replace the <a>context object</a>'s
-        `options` with <var>options</var>.
-        </li>
-        <li>Otherwise, append a new <a>registered performance observer</a>
-        object to the list of <a>registered performance observer</a> objects
-        associated with the <a>ECMAScript global environment</a> of the
-        interface object, with the <a>context object</a> as `observer` and
-        <var>options</var> as the `options`.
-        </li>
-      </ol>
-      <section>
-        <h3><dfn>disconnect()</dfn></h3>
-        <p>The <a>disconnect()</a> method must remove the <a>context object</a>
-        from the list of <a>PerformanceObserver</a> objects associated with the
-        <a>ECMAScript global environment</a> of the interface object, and also
-        empty <a>context object</a>'s <a>observer buffer</a>.</p>
-      </section>
-    </section>
-  </section>
-  <section data-dfn-for="PerformanceObserverEntryList" data-link-for=
-  "PerformanceObserverEntryList">
-    <h2><dfn>PerformanceObserverEntryList</dfn> interface</h2>
-    <pre class="idl">
-    [Exposed=(Window,Worker)]
-    interface PerformanceObserverEntryList {
-      PerformanceEntryList getEntries();
-      PerformanceEntryList getEntriesByType (DOMString type);
-      PerformanceEntryList getEntriesByName (DOMString name, optional DOMString type);
-    };
-    </pre>
-    <section>
-      <h2><dfn>getEntries()</dfn> method</h2>
-      <p>...</p>
-    </section>
-    <section>
-      <h2><dfn>getEntriesByType()</dfn> method</h2>
-      <p>...</p>
-    </section>
-    <section>
-      <h2><dfn>getEntriesByName()</dfn> method</h2>
-      <p>...</p>
-    </section>
-  </section>
-  <section>
-    <h2>Processing</h2>
     <section data-link-for="PerformanceEntry">
-      <h2>Filter <a>performance entry buffer</a> by <var>name</var> and
-      <var>type</var></h2>
-      <p>Given optional <var>name</var> and <var>type</var> string values this
-      algorithm returns a <a>PerformanceEntryList</a> object that contains a
-      list of <a>PerformanceEntry</a> objects sorted in chronological order
-      with respect to <a>startTime</a>; objects with the same <a>startTime</a>
-      have unspecified ordering.</p>
+      <h2>Filter <var>buffer</var> by <var>name</var> and <var>type</var></h2>
+      <p>Given a <var>buffer</var> and optional <var>name</var> and
+      <var>type</var> string values this algorithm returns a
+      <a>PerformanceEntryList</a> object that contains a list of
+      <a>PerformanceEntry</a> objects sorted in chronological order with respect
+      to <a>startTime</a>; objects with the same <a>startTime</a> have
+      unspecified ordering.</p>
       <ol>
         <li>Let the <dfn>list of entry objects</dfn> be the empty
         <a>PerformanceEntryList</a>.
         </li>
         <li>For each <a>PerformanceEntry</a> object (<dfn>entryObject</dfn>) in
-        the <a>performance entry buffer</a>, in chronological order with
+        the <var>buffer</var>, in chronological order with
         respect to <a>startTime</a>:
           <ol>
             <li>If <var>name</var> is not `null` and <a>entryObject</a>'s

--- a/index.html
+++ b/index.html
@@ -318,9 +318,6 @@
       <p>The <dfn>observe()</dfn> method instructs the user agent to
       <dfn>register the observer</dfn> and must run these steps:</p>
       <ol data-link-for="PerformanceObserverInit">
-        <li>If _options'_ <a>entryTypes</a> attribute is not present,
-        <a>throw</a> a JavaScript `TypeError`.
-        </li>
         <li>Filter unsupported names within the `entryTypes` sequence, and
         replace the `entryTypes` sequence with the new filtered sequence.</li>
         <li>If the _options'_ <a>entryTypes</a> attribute is an empty sequence,


### PR DESCRIPTION
A whole bunch of editorial + cleanup updates. No functional changes.     

- Builds on https://github.com/w3c/performance-timeline/pull/72#issuecomment-283581201.
- Moved filter method into processing
- Made filter method take a buffer
- Updated ObserverEntryList definitions to call filter method
- More logical order to the sections
- tidy formatted

The diff is scary looking, but mostly due to tidy (re)formatting. Take a look at the preview instead:
https://cdn.rawgit.com/w3c/performance-timeline/b816729b692fb136a3f12957ac298d9c5652311b/index.html