### PR TITLE
the `buffered` part of the processing algorithm needs to move above the potential short-circuit

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,6 +449,9 @@
           </li>
         </ol>
       </li>
+      <li>If the <var>add to performance entry buffer</var> flag is set, add
+        <i>new entry</i> to the <a>performance entry buffer</a>.
+      </li>
       <li>If the <a>performance observer task queued flag</a> is set, terminate
       these steps.
       </li>
@@ -481,9 +484,6 @@
             </ol>
           </li>
         </ol>
-      </li>
-      <li>If the <var>add to performance entry buffer</var> flag is set, add
-      <i>new entry</i> to the <a>performance entry buffer.</a>
       </li>
     </ol>
     <p>The <i>performance timeline</i> <a>task queue</a> is a low priority


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/cvazac/performance-timeline/gh-pages.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/performance-timeline/d1f1214...cvazac:e90f4ba.html)