### PR TITLE
Fix auto-publish

### DIFF
--- a/W3CTRMANIFEST
+++ b/W3CTRMANIFEST
@@ -1,1 +1,1 @@
-index.html?specStatus=WD;shortName=performance-timeline-2;useExperimentalStyles=false respec
+index.html?specStatus=CR;shortName=performance-timeline-2;useExperimentalStyles=false respec


### PR DESCRIPTION
[Auto-publishing is currently failing](https://lists.w3.org/Archives/Public/public-tr-notifications/2017Jul/0046.html) because it thinks you are trying to republish the document as a Working Draft. You should continue to make non-normative changes to this spec, and publish them as CR. 

Otherwise, if you are making substantive changes to the spec (that would warrant dropping back to WD), you might want to disable auto publishing entirely.