### PR TITLE
observing an empty sequence of entryTypes is a no-op

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,7 +329,8 @@
         </li>
         <li>If the resulting '<a>entryTypes</a>' sequence is an empty sequence, abort
           these steps. The user agent SHOULD notify developers when the steps are
-          aborted. A console warning might be appropriate, for example.
+          aborted. A console warning listing ignored unsupported names in `entryTypes`
+          might be appropriate, for example.
         </li>
         <li>If the list of <a>registered performance observer</a> objects
         associated with the <a>ECMAScript global environment</a> of the

--- a/index.html
+++ b/index.html
@@ -327,8 +327,9 @@
         <li>Filter unsupported names within the `entryTypes` sequence, and
         replace the `entryTypes` sequence with the new filtered sequence.
         </li>
-        <li>If the resulting '<a>entryTypes</a>' sequence is an empty sequence, abort these steps.</li>
-        <p class='note'>User agents are encouraged to log this fact in a developer console, to aid debugging.</p>
+        <li>If the resulting '<a>entryTypes</a>' sequence is an empty sequence, abort
+          these steps. The user agent SHOULD notify developers when the steps are
+          aborted. A console warning might be appropriate, for example.
         </li>
         <li>If the list of <a>registered performance observer</a> objects
         associated with the <a>ECMAScript global environment</a> of the

--- a/index.html
+++ b/index.html
@@ -325,9 +325,10 @@
       <dfn>register the observer</dfn> and must run these steps:</p>
       <ol data-link-for="PerformanceObserverInit">
         <li>Filter unsupported names within the `entryTypes` sequence, and
-        replace the `entryTypes` sequence with the new filtered sequence.</li>
-        <li>If the _options'_ <a>entryTypes</a> attribute is an empty sequence,
-        <a>throw</a> a JavaScript `TypeError`.
+        replace the `entryTypes` sequence with the new filtered sequence.
+        </li>
+        <li>If the resulting '<a>entryTypes</a>' sequence is an empty sequence, abort these steps.</li>
+        <p class='note'>User agents are encouraged to log this fact in a developer console, to aid debugging.</p>
         </li>
         <li>If the list of <a>registered performance observer</a> objects
         associated with the <a>ECMAScript global environment</a> of the


### PR DESCRIPTION
This is a proposed fix for #87


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/performance-timeline/perf-timeline/observe/typeerr.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/performance-timeline/ec04827...4e15343.html)