### PR TITLE
Fix links after dependency removal

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
     <p>Performance Timeline Level 2 replaces the first version of
     [[PERFORMANCE-TIMELINE]] and includes:</p>
     <ul>
-      <li>Extends the base definition of the <a data-cite="!hr-time-2#idl-def-Performance">Performance</a> interface
+      <li>Extends the base definition of the <a data-cite="!hr-time-2#sec-performance">Performance</a> interface
       defined by [[HR-TIME-2]];
       </li>
       <li>Exposes <a>PerformanceEntry</a> in Web Workers [[WORKERS]];
@@ -202,8 +202,8 @@
     <p>The <dfn>relevant performance entry buffer</dfn> is the <a>performance entry buffer</a> associated with the
     <a data-cite="!WHATWG-HTML#concept-relevant-global">relevant global object</a>.</p>
     <section data-dfn-for="Performance" data-link-for="Performance">
-      <h2>Extensions to the <dfn data-cite="!hr-time-2#idl-def-Performance">Performance</dfn> interface</h2>
-      <p>This extends the <a data-cite="!hr-time-2#idl-def-Performance">Performance</a> interface [[!HR-TIME-2]] and hosts
+      <h2>Extensions to the <dfn data-cite="!hr-time-2#sec-performance">Performance</dfn> interface</h2>
+      <p>This extends the <a data-cite="!hr-time-2#sec-performance">Performance</a> interface [[!HR-TIME-2]] and hosts
       performance related attributes and methods used to retrieve the
       performance metric data from the <a>Performance Timeline</a>.</p>
       <pre class="idl">
@@ -536,7 +536,7 @@
   </section>
   <section id="privacy-security">
     <h3>Privacy and Security</h3>
-    <p>This specification extends the <a data-cite="!hr-time-2#idl-def-Performance">Performance</a> interface defined by
+    <p>This specification extends the <a data-cite="!hr-time-2#sec-performance">Performance</a> interface defined by
     [[HR-TIME-2]] and provides methods to queue and retrieve entries from the
     <a>performance timeline</a>. Please refer to [[HR-TIME-2]] for privacy and
     security considerations of exposing high-resoluting timing information.</p>


### PR DESCRIPTION
https://github.com/w3c/performance-timeline/pull/107 broke a couple of links. This fixes them.

/cc @npm1


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/performance-timeline/pull/109.html" title="Last updated on Oct 10, 2018, 8:33 PM GMT (b64fc35)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/109/df33799...yoavweiss:b64fc35.html" title="Last updated on Oct 10, 2018, 8:33 PM GMT (b64fc35)">Diff</a>