### PR TITLE
Fix a link to filter algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -444,7 +444,7 @@
             <li>If <var>options</var>'s <a>buffered</a> flag is set:
               <ol>
                 <li>Let <var>entries</var> be the <a>PerformanceEntryList</a>
-                object returned by <a href="#filter-buffer-by-name-and-type"></a>
+                object returned by <a href="#filter-buffer-by-name-and-type">§ Filter buffer by name and type</a>
                 algorithm with <var>buffer</var> set to <a>relevant
                 performance entry buffer</a>, <var>name</var> set to
                 <code>null</code> and <var>type</var> set to

--- a/index.html
+++ b/index.html
@@ -444,8 +444,8 @@
             <li>If <var>options</var>'s <a>buffered</a> flag is set:
               <ol>
                 <li>Let <var>entries</var> be the <a>PerformanceEntryList</a>
-                object returned by the <a href="#filter-buffer-by-name-and-type">
-                </a> algorithm with <var>buffer</var> set to <a>relevant
+                object returned by <a href="#filter-buffer-by-name-and-type"></a>
+                algorithm with <var>buffer</var> set to <a>relevant
                 performance entry buffer</a>, <var>name</var> set to
                 <code>null</code> and <var>type</var> set to
                 <var>options</var>'s <a>type</a>.


### PR DESCRIPTION
It seems that the whole href has to be in a single line for the link to be used with the algorithm name.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/pull/115.html" title="Last updated on Mar 20, 2019, 2:48 PM UTC (cd61fc4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/115/0534f9c...cd61fc4.html" title="Last updated on Mar 20, 2019, 2:48 PM UTC (cd61fc4)">Diff</a>