### PR TITLE
Fix a link to filter algorithm again

### DIFF
--- a/index.html
+++ b/index.html
@@ -444,7 +444,7 @@
             <li>If <var>options</var>'s <a>buffered</a> flag is set:
               <ol>
                 <li>Let <var>entries</var> be the <a>PerformanceEntryList</a>
-                object returned by <a href="#filter-buffer-by-name-and-type">§ Filter buffer by name and type</a>
+                object returned by <a href="#filter-buffer-by-name-and-type"></a>
                 algorithm with <var>buffer</var> set to <a>relevant
                 performance entry buffer</a>, <var>name</var> set to
                 <code>null</code> and <var>type</var> set to


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/pull/116.html" title="Last updated on Mar 21, 2019, 2:34 AM UTC (c102386)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/116/aaad0f2...c102386.html" title="Last updated on Mar 21, 2019, 2:34 AM UTC (c102386)">Diff</a>