### PR TITLE
supportedEntryTypes: cache the FrozenArray

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,23 +199,22 @@
       <li>A <dfn>performance entry buffer</dfn> to store
       <a>PerformanceEntry</a> objects that is initially empty.
       </li>
-      <li>A list of <dfn>supported entry types</dfn>, which contains the strings
-        representing the entry types which the user agent supports for the
-        <a>PerformanceObserver</a> interface within that environment. This list
-        is populated by specifications that define new entry types via the
-        <a>register a performance entry type</a> algorithm.
-      </li>
       <li>
         A <dfn>frozen supported entry types</dfn> representing the cached
         <a data-cite="WebIDL#idl-frozen-array">FrozenArray</a> for that
-        <a data-cite="WebIDL#es-environment">ECMAScript global environment</a>,
-        which is initially <code>null</code>.
+        <a data-cite="WebIDL#es-environment">ECMAScript global environment</a>.
+        The contents of this array are determined by specifications which define
+        new entry types.
       </li>
     </ul>
     <p>The <dfn>relevant performance entry buffer</dfn> is the <a>performance
     entry buffer</a> associated with the <a data-cite=
     "HTML/webappapis.html#concept-relevant-global">relevant global
     object</a>.</p>
+    <p>The <dfn>relevant supported entry types</dfn> is the <a>frozen supported
+    entry types</a> associated with the <a data-cite=
+    "HTML/webappapis.html#concept-relevant-global">relevant global object</a>.
+    </p>
     <section data-dfn-for="Performance" data-link-for="Performance">
       <h2>Extensions to the <dfn data-cite=
       "hr-time-2#sec-performance">Performance</dfn> interface</h2>
@@ -397,10 +396,10 @@
             <a>entryTypes</a> sequence.
             </li>
             <li>Remove all types from <var>entry types</var> that are not
-            contained in <a>supported entry types</a>. The user agent SHOULD
-            notify developers if <var>entry types</var> is modified. For
-            example, a console warning listing removed types might be
-            appropriate.</li>
+            contained in the <a>relevant supported entry types</a>. The user
+            agent SHOULD notify developers if <var>entry types</var> is
+            modified. For example, a console warning listing removed types might
+            be appropriate.</li>
             <li>If the resulting <var>entry types</var> sequence is an empty
             sequence, abort these steps. The user agent SHOULD notify developers
             when the steps are aborted to notify that registration has been
@@ -426,9 +425,9 @@
           <ol>
             <li>Assert that <var>observer</var>'s <a>observer type</a> is
             <code>"single"</code>.</li>
-            <li>If <var>options</var>'s <a>type</a> is not contained in
-            <a>supported entry types</a>, abort these steps. The user agent
-            SHOULD notify developers when this happens, for instance via a
+            <li>If <var>options</var>'s <a>type</a> is not contained in the
+            <a>relevant supported entry types</a>, abort these steps. The user
+            agent SHOULD notify developers when this happens, for instance via a
             console warning.</li>
             <li>If the <a>list of registered performance observer objects</a> of
             <a data-cite="HTML/webappapis.html#concept-relevant-global">relevant
@@ -573,24 +572,8 @@
       </section>
       <section data-link-for="PerformanceObserver">
         <h2><a>supportedEntryTypes</a> attribute</h2>
-        <p>When <dfn>supportedEntryTypes</dfn>'s attribute getter is called, run the following steps:</p>
-        <ol>
-          <li>
-            If the <a data-cite="HTML/webappapis.html#concept-relevant-global">
-            relevant global object</a>'s <a>frozen supported entry types</a> is
-            not <code>null</code>, return it.
-          </li>
-          <li>
-            Otherwise, initialize the
-            <a data-cite="HTML/webappapis.html#concept-relevant-global">
-            relevant global object</a>'s <a>frozen supported entry types</a> to
-            the value returned by the
-            <a data-cite="WEBIDL#dfn-create-frozen-array">
-            create a frozen array</a> algorithm, passing in the
-            <a data-cite="HTML/webappapis.html#concept-relevant-global">
-            relevant global object</a>'s <a>supported entry types</a>.
-          </li>
-        </ol>
+        <p>When <dfn>supportedEntryTypes</dfn>'s attribute getter is called, it
+          MUST return the <a>relevant supported entry types</a>.</p>
         <p class="note">This attribute allows web developers to easily know
         which entry types are supported by the user agent.</p>
       </section>
@@ -712,15 +695,6 @@
         </li>
         <li>Return the <var>list of entry objects</var>.
         </li>
-      </ol>
-    </section>
-    <section data-link-for="PerformanceObserver">
-      <h2>Register performance entry type</h2>
-      <p>To <dfn>register a performance entry type</dfn> in a <a data-cite="WebIDL#es-environment">ECMAScript global
-    environment</a> <var>environment</var>, run the following steps:</p>
-      <ol>
-        <li>Let <var>type</var> be the input string.</li>
-        <li>Append <var>type</var> to <var>environment</var>'s <a>supported entry types</a>.</li>
       </ol>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -193,11 +193,23 @@
     <p>Each <a data-cite="WebIDL#es-environment">ECMAScript global
     environment</a> has:</p>
     <ul>
-      <li>a <dfn>performance observer task queued flag</dfn></li>
-      <li>a <dfn>list of <a>registered performance observer</a> objects</dfn>
-      that is initially empty</li>
-      <li>a <dfn>performance entry buffer</dfn> to store
-      <a>PerformanceEntry</a> objects that is initially empty
+      <li>A <dfn>performance observer task queued flag</dfn>.</li>
+      <li>A <dfn>list of <a>registered performance observer</a> objects</dfn>
+      that is initially empty.</li>
+      <li>A <dfn>performance entry buffer</dfn> to store
+      <a>PerformanceEntry</a> objects that is initially empty.
+      </li>
+      <li>A list of <dfn>supported entry types</dfn>, which contains the strings
+        representing the entry types which the user agent supports for the
+        <a>PerformanceObserver</a> interface within that environment. This list
+        is populated by specifications that define new entry types via the
+        <a>register a performance entry type</a> algorithm.
+      </li>
+      <li>
+        A <dfn>frozen supported entry types</dfn> representing the cached
+        <a data-cite="WebIDL#idl-frozen-array">FrozenArray</a> for that
+        <a data-cite="WebIDL#es-environment">ECMAScript global environment</a>,
+        which is initially <code>null</code>.
       </li>
     </ul>
     <p>The <dfn>relevant performance entry buffer</dfn> is the <a>performance
@@ -326,7 +338,7 @@
         void observe (PerformanceObserverInit options);
         void disconnect ();
         PerformanceEntryList takeRecords();
-        static readonly attribute FrozenArray&lt;DOMString&gt; supportedEntryTypes;
+        [ SameObject ] static readonly attribute FrozenArray&lt;DOMString&gt; supportedEntryTypes;
       };
       </pre>
       <p class="note">To keep the performance overhead to minimum the
@@ -559,18 +571,25 @@
         "WHATWG-DOM#context-object">context object</a>'s <a>observer
         buffer</a>.</p>
       </section>
-      <section>
+      <section data-link-for="PerformanceObserver">
         <h2><a>supportedEntryTypes</a> attribute</h2>
-        <p>The user agent MUST maintain <dfn>supported entry types</dfn>, a list
-        of strings representing the entry types which the user agent supports
-        for the <a>PerformanceObserver</a> interface. This list is populated by
-        specifications that define new entry types via the
-        <a>register a performance entry type</a> algorithm.</p>
         <p>When <dfn>supportedEntryTypes</dfn>'s attribute getter is called, run the following steps:</p>
         <ol>
-          <li>Let <var>result</var> be a copy of the user agent's <a>supported entry types</a>.</li>
-          <li>Sort <var>result</var> in alphabetical order.</li>
-          <li>Return <var>result</var>.</li>
+          <li>
+            If the <a data-cite="HTML/webappapis.html#concept-relevant-global">
+            relevant global object</a>'s <a>frozen supported entry types</a> is
+            not <code>null</code>, return it.
+          </li>
+          <li>
+            Otherwise, initialize the
+            <a data-cite="HTML/webappapis.html#concept-relevant-global">
+            relevant global object</a>'s <a>frozen supported entry types</a> to
+            the value returned by the
+            <a data-cite="WEBIDL#dfn-create-frozen-array">
+            create a frozen array</a> algorithm, passing in the
+            <a data-cite="HTML/webappapis.html#concept-relevant-global">
+            relevant global object</a>'s <a>supported entry types</a>.
+          </li>
         </ol>
         <p class="note">This attribute allows web developers to easily know
         which entry types are supported by the user agent.</p>
@@ -697,10 +716,11 @@
     </section>
     <section data-link-for="PerformanceObserver">
       <h2>Register performance entry type</h2>
-      <p>To <dfn>register a performance entry type</dfn>, run the following steps:</p>
+      <p>To <dfn>register a performance entry type</dfn> in a <a data-cite="WebIDL#es-environment">ECMAScript global
+    environment</a> <var>environment</var>, run the following steps:</p>
       <ol>
         <li>Let <var>type</var> be the input string.</li>
-        <li>Append <var>type</var> to <a>supported entry types</a>.</li>
+        <li>Append <var>type</var> to <var>environment</var>'s <a>supported entry types</a>.</li>
       </ol>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -199,23 +199,22 @@
       <li>A <dfn>performance entry buffer</dfn> to store
       <a>PerformanceEntry</a> objects that is initially empty.
       </li>
-      <li>
-        A <dfn>frozen supported entry types</dfn> representing the cached
-        <a data-cite="WebIDL#idl-frozen-array">FrozenArray</a> for that
-        <a data-cite="WebIDL#es-environment">ECMAScript global environment</a>.
-        The contents of this array are determined by specifications which define
-        new entry types. The contents of this array MUST be in alphabetical
-        order.
+      <li>A <dfn>list of supported entry types</dfn> that is initially empty.
+      The contents of this list are determined by specifications which define
+      new entry types. The contents of this list MUST be in alphabetical order.
+      </li>
+      <li>A <dfn>frozen supported entry types</dfn> representing the
+      <a data-cite="WebIDL#idl-frozen-array">FrozenArray</a> that corresponds
+      with the <a>list of supported entry types</a>.
       </li>
     </ul>
     <p>The <dfn>relevant performance entry buffer</dfn> is the <a>performance
     entry buffer</a> associated with the <a data-cite=
     "HTML/webappapis.html#concept-relevant-global">relevant global
-    object</a>.</p>
-    <p>The <dfn>relevant supported entry types</dfn> is the <a>frozen supported
+    object</a> of the <a data-cite="DOM#context-object">context object</a>.</p>
+    <p>The <dfn>relevant supported entry types</dfn> is the <a>list of supported
     entry types</a> associated with the <a data-cite=
-    "HTML/webappapis.html#concept-relevant-global">relevant global object</a>.
-    </p>
+    "HTML/webappapis.html#current-global-object">current global object</a>.</p>
     <section data-dfn-for="Performance" data-link-for="Performance">
       <h2>Extensions to the <dfn data-cite=
       "hr-time-2#sec-performance">Performance</dfn> interface</h2>
@@ -574,7 +573,19 @@
       <section data-link-for="PerformanceObserver">
         <h2><a>supportedEntryTypes</a> attribute</h2>
         <p>When <dfn>supportedEntryTypes</dfn>'s attribute getter is called, it
-          MUST return the <a>relevant supported entry types</a>.</p>
+        MUST run the following steps:
+        <ol>
+          <li>If the <a>frozen supported entry types</a> of the <a data-cite=
+          "HTML/webappapis.html#current-global-object">current global object</a>
+          has been initialized, then return it.</li>
+          <li>Otherwise, initialize the <a>frozen supported entry types</a> of
+          the <a data-cite="HTML/webappapis.html#current-global-object">current
+          global object</a> to the output of the <a data-cite=
+          "WEBIDL#dfn-create-frozen-array">create a frozen array</a> algorithm
+          with the <a>relevant supported entry types</a> as input, and return
+          it.</li>
+        </ol>
+        </p>
         <p class="note">This attribute allows web developers to easily know
         which entry types are supported by the user agent.</p>
       </section>
@@ -698,6 +709,18 @@
         </li>
       </ol>
     </section>
+  </section>
+  <section data-link-for="PerformanceObserver"> 
+    <h2>Register performance entry type</h2>  
+    <p>To <dfn>register a performance entry type</dfn>, run the following steps:</p>  
+    <ol>
+      <li>Let <var>global object</var> be the input <a data-cite=
+      "HTML/webappapis.html#concept-realm-global">global object</a>.</li>
+      <li>Let <var>type</var> be the input string.</li> 
+      <li>Add <var>type</var> to the <a>list of supported entry types</a> of
+      <var>global object</var> in a location such that its contents remain in
+      alphabetical order.</li>
+    </ol> 
   </section>
   <section id="privacy-security">
     <h3>Privacy and Security</h3>

--- a/index.html
+++ b/index.html
@@ -204,7 +204,8 @@
         <a data-cite="WebIDL#idl-frozen-array">FrozenArray</a> for that
         <a data-cite="WebIDL#es-environment">ECMAScript global environment</a>.
         The contents of this array are determined by specifications which define
-        new entry types.
+        new entry types. The contents of this array MUST be in alphabetical
+        order.
       </li>
     </ul>
     <p>The <dfn>relevant performance entry buffer</dfn> is the <a>performance


### PR DESCRIPTION
This change does the following:
* Cache the result from PerformanceObserver's attribute getter in |frozen supported entry types|, and mention that other specs determine its contents.
* Remove the non-frozen list and the hook to add to that list.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/pull/118.html" title="Last updated on May 6, 2019, 9:39 PM UTC (08f743c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/118/58b1f72...08f743c.html" title="Last updated on May 6, 2019, 9:39 PM UTC (08f743c)">Diff</a>