### PR TITLE
Make observe() parameter an optional dictionary

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,7 +323,7 @@
                                                    PerformanceObserver observer);
       [Constructor(PerformanceObserverCallback callback), Exposed=(Window,Worker)]
       interface PerformanceObserver {
-        void observe (PerformanceObserverInit options);
+        void observe (optional PerformanceObserverInit options);
         void disconnect ();
         PerformanceEntryList takeRecords();
         static readonly attribute FrozenArray&lt;DOMString&gt; supportedEntryTypes;


### PR DESCRIPTION
It seems that it must be made optional to confirm with WebIDL spec. Fortunately the observe() processing will already throw if 'entryTypes' and 'type' are both omitted (which is what would happen if the parameter is missing, as an empty dictionary is assumed), so no additional changes are required.
Solves https://github.com/w3c/performance-timeline/issues/119
@whh8b FYI


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/pull/120.html" title="Last updated on Mar 28, 2019, 4:21 PM UTC (c93fbf8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/120/3139cce...c93fbf8.html" title="Last updated on Mar 28, 2019, 4:21 PM UTC (c93fbf8)">Diff</a>