### PR TITLE
Backport the relevant global object definition for the relevant performance entry buffer

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
     <p>The <dfn>relevant performance entry buffer</dfn> is the <a>performance
     entry buffer</a> associated with the <a data-cite=
     "HTML/webappapis.html#concept-relevant-global">relevant global
-    object</a>.</p>
+    object</a> of the <a data-cite="DOM#context-object">context object</a>.</p>
     <section data-dfn-for="Performance" data-link-for="Performance">
       <h2>Extensions to the <dfn data-cite=
       "hr-time-2#sec-performance">Performance</dfn> interface</h2>


### PR DESCRIPTION
Closes #122


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/performance-timeline/pull/129.html" title="Last updated on May 14, 2019, 1:51 PM UTC (eff1233)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/129/09e1844...yoavweiss:eff1233.html" title="Last updated on May 14, 2019, 1:51 PM UTC (eff1233)">Diff</a>