### PR TITLE
Update buffer map initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@
       <li>a <dfn>performance observer task queued flag</dfn></li>
       <li>a <dfn>list of <a>registered performance observer</a> objects</dfn>
       that is initially empty</li>
-      <li>an initially empty <dfn>performance entry buffer map</dfn> <a
+      <li>a <dfn>performance entry buffer map</dfn> <a
       data-cite="WHATWG-INFRA#ordered-map">map</a>, <a
       data-cite="WHATWG-INFRA#map-key">keyed</a> on a <code>DOMString</code>,
       representing the entry type to which the buffer belongs. The <a
@@ -205,15 +205,15 @@
         <ul>
           <li>A <dfn>performance entry buffer</dfn> to store
             <a>PerformanceEntry</a> objects, that is initially empty.</li>
-          <li>A <dfn>maxBufferSize</dfn> indicating the max
-            buffer size for this entry type, initialized to the <a href=
+          <li>A <a href="https://w3c.github.io/timing-entrytypes-registry/#registration">
+            <dfn>maxBufferSize</dfn></a>, initialized to the <a href=
             "https://w3c.github.io/timing-entrytypes-registry/#registry">registry</a>
             value for this entry type.</li>
-          <li>A <code>boolean</code> <dfn>availableFromTimeline</dfn>
-            indicating whether this entry type is available from the
-            <a>Performance</a> interface, initialized to the <a href=
+          <li>A <code>boolean</code> <a href=
+            "https://w3c.github.io/timing-entrytypes-registry/#registration">
+            availableFromTimeline</a>, initialized to the <a href=
             "https://w3c.github.io/timing-entrytypes-registry/#registry">registry</a>
-             value for this entry type.</li>
+            value for this entry type.</li>
         </ul>
       </li>
     </ul>
@@ -296,7 +296,7 @@
         <dd>
           This attribute MUST return the type of the interface represented by
           this <a>PerformanceEntry</a> object.
-          <p class="note">All `entryType` values are defined in the <a href=
+          <p class="note">All `entryType` values are defined in the relevant<a href=
           "https://w3c.github.io/timing-entrytypes-registry/#registry">registry</a>.
           Examples include: <code>"mark"</code> and
           <code>"measure"</code> [[USER-TIMING-2]], <code>"navigation"</code>

--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
     particular, the algorithms defined in this specification are intended to be
     easy to follow, and not intended to be performant.)</p>
   </section>
-  <section>
+  <section data-dfn-for="PerformanceTimeline" data-link-for="PerformanceTimeline">
     <h2><dfn>Performance Timeline</dfn></h2>
     <p>Each <a data-cite="WebIDL#es-environment">ECMAScript global
     environment</a> has:</p>
@@ -206,10 +206,14 @@
           <li>A <dfn>performance entry buffer</dfn> to store
             <a>PerformanceEntry</a> objects, that is initially empty.</li>
           <li>A <dfn>maxBufferSize</dfn> indicating the max
-            buffer size for this entry type.</li>
+            buffer size for this entry type, initialized to the <a href=
+            "https://w3c.github.io/timing-entrytypes-registry/#registry">registry</a>
+            value for this entry type.</li>
           <li>A <code>boolean</code> <dfn>availableFromTimeline</dfn>
             indicating whether this entry type is available from the
-            <a>Performance</a> interface.</li>
+            <a>Performance</a> interface, initialized to the <a href=
+            "https://w3c.github.io/timing-entrytypes-registry/#registry">registry</a>
+             value for this entry type.</li>
         </ul>
       </li>
     </ul>
@@ -292,8 +296,9 @@
         <dd>
           This attribute MUST return the type of the interface represented by
           this <a>PerformanceEntry</a> object.
-          <p class="note">Example `entryType` values defined by other
-          specifications include: <code>"mark"</code> and
+          <p class="note">All `entryType` values are defined in the <a href=
+          "https://w3c.github.io/timing-entrytypes-registry/#registry">registry</a>.
+          Examples include: <code>"mark"</code> and
           <code>"measure"</code> [[USER-TIMING-2]], <code>"navigation"</code>
           [[NAVIGATION-TIMING-2]], <code>"resource"</code>
           [[RESOURCE-TIMING-2]], <!-- TODO: add long task spec reference -->

--- a/index.html
+++ b/index.html
@@ -39,6 +39,12 @@
       testSuiteURI:
         "https://github.com/web-platform-tests/wpt/tree/master/performance-timeline",
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/45211/status",
+      lint: {
+        "check-punctuation": true,
+      },
+      doJsonLd: true,
+      xref: "web-platform",
+      mdn: true,
     };
   </script>
 </head>
@@ -186,22 +192,21 @@
     <p>Conformance requirements phrased as algorithms or specific steps may be
     implemented in any manner, so long as the end result is equivalent. (In
     particular, the algorithms defined in this specification are intended to be
-    easy to follow, and not intended to be performant.)</p>
+    easy to follow, and not intended to be performant).</p>
   </section>
-  <section data-dfn-for="PerformanceTimeline" data-link-for="PerformanceTimeline">
+  <section>
     <h2><dfn>Performance Timeline</dfn></h2>
-    <p>Each <a data-cite="WebIDL#es-environment">ECMAScript global
-    environment</a> has:</p>
+    <p>Each <a>ECMAScript global environment</a> has:</p>
     <ul>
       <li>a <dfn>performance observer task queued flag</dfn></li>
       <li>a <dfn>list of <a>registered performance observer</a> objects</dfn>
       that is initially empty</li>
-      <li>a <dfn>performance entry buffer map</dfn> <a
-      data-cite="WHATWG-INFRA#ordered-map">map</a>, <a
-      data-cite="WHATWG-INFRA#map-key">keyed</a> on a <code>DOMString</code>,
-      representing the entry type to which the buffer belongs. The <a
-      data-cite="WHATWG-INFRA#ordered-map">map</a>'s <a
-      data-cite="WHATWG-INFRA#map-value">value</a> is the following tuple:
+      <li>a <dfn>performance entry buffer map</dfn>
+      <a>map</a>,
+      <a>keyed</a> on a <code>DOMString</code>,
+      representing the entry type to which the buffer belongs. The
+      <a>map</a>'s
+      <a>value</a> is the following tuple:
         <ul>
           <li>A <dfn>performance entry buffer</dfn> to store
             <a>PerformanceEntry</a> objects, that is initially empty.</li>
@@ -221,12 +226,9 @@
     <var>entryType</var> as input, run the following steps:</p>
     <ol>
       <li>Let <var>map</var> be the <a>performance entry buffer map</a> associated
-      with the <a data-cite="HTML/webappapis.html#concept-relevant-global">
-      relevant global object</a> of the <a data-cite="DOM#context-object">
-      context object</a>.</li>
-      <li>Return the value returned when <a
-      data-cite="WHATWG-INFRA#map-get">getting the value of an entry</a>, given
-      <var>entryType</var> as <a data-cite="WHATWG-INFRA#map-key">key</a>.</li>
+      with the <a>relevant global object</a> of the <a>context object</a>.</li>
+      <li>Return the value returned when <a>getting the value of an entry</a>, given
+      <var>entryType</var> as <a>key</a>.</li>
     </ol>
 
     <section data-dfn-for="Performance" data-link-for="Performance">
@@ -320,8 +322,7 @@
           <code>0</code>.
         </dd>
       </dl>
-      <p>When <dfn>toJSON</dfn> is called, run [[WebIDL]]'s <a data-cite=
-      "WEBIDL#default-tojson-operation">default toJSON operation</a>.</p>
+      <p>When <dfn>toJSON</dfn> is called, run [[WebIDL]]'s <a>default toJSON operation</a>.</p>
     </section>
     <section data-link-for="PerformanceObserver" data-dfn-for=
     "PerformanceObserver">
@@ -340,8 +341,7 @@
       <p>The `PerformanceObserver(callback)` constructor must create a new
       <a>PerformanceObserver</a> object with <a>PerformanceObserverCallback</a>
       set to <var>callback</var> and then return it.</p>
-      <p>A <dfn>registered performance observer</dfn> is a <a data-cite=
-      "WHATWG-INFRA#struct">struct</a> consisting of an
+      <p>A <dfn>registered performance observer</dfn> is a <a>struct</a> consisting of an
       <dfn>observer</dfn> member (a <a>PerformanceObserver</a> object) and an
       <dfn>options list</dfn> member (a list of <a>PerformanceObserverInit</a>
       dictionaries).</p>
@@ -367,18 +367,16 @@
         <p>The <a>observe()</a> method instructs the user agent to
         <dfn>register the observer</dfn> and must run these steps:</p>
         <ol data-link-for="PerformanceObserverInit">
-          <li>Let <var>observer</var> be the <a data-cite=
-            "WHATWG-DOM#context-object">context object</a>.</li>
-          <li>Let <var>relevantGlobal</var> be <var>observer</var>'s <a data-cite=
-          "HTML/webappapis.html#concept-relevant-global">relevant global
+          <li>Let <var>observer</var> be the <a>context object</a>.</li>
+          <li>Let <var>relevantGlobal</var> be <var>observer</var>'s <a>relevant global
           object</a>.</li>
           <li>If <var>options</var>'s <a>entryTypes</a> and <a>type</a> members
-          are both omitted, then <a data-cite="WEBIDL#dfn-throw">throw</a> a
-          <a data-cite="WEBIDL#syntaxerror"><code>SyntaxError</code></a>.</li>
+          are both omitted, then <a>throw</a> a
+          <a>SyntaxError</a>.</li>
           <li>If <var>options</var>'s <a>entryTypes</a> is present and any other
           member is also present, then
-          <a data-cite="WEBIDL#dfn-throw">throw</a> a
-          <a data-cite="WEBIDL#syntaxerror"><code>SyntaxError</code></a>.</li>
+          <a>throw</a> a
+          <a>SyntaxError</a>.</li>
           <li>Update or check <var>observer</var>'s <a>observer type</a> by
           running these steps:
             <ol>
@@ -396,15 +394,13 @@
               <li>If <var>observer</var>'s <a>observer type</a> is
               <code>"single"</code> and <var>options</var>'s
               <a>entryTypes</a> member is present, then
-              <a data-cite="WEBIDL#dfn-throw">throw</a> an
-              <a data-cite="WEBIDL#invalidmodificationerror">
-              <code>InvalidModificationError</code></a>.
+              <a>throw</a> an
+              <a>InvalidModificationError</a>.
               </li>
               <li>If <var>observer</var>'s <a>observer type</a> is
               <code>"multiple"</code> and <var>options</var>'s <a>type</a>
-              member is present, then <a data-cite="WEBIDL#dfn-throw">throw</a>
-              an <a data-cite="WEBIDL#invalidmodificationerror">
-              <code>InvalidModificationError</code></a>.
+              member is present, then <a>throw</a>
+              an <a>InvalidModificationError</a>.
               </li>
             </ol>
           </li>
@@ -424,16 +420,14 @@
             aborted. For example, a console warning might be appropriate.</li>
             <li>If the <a>list of registered performance observer objects</a> of
             <var>relevantGlobal</var> contains a <a>registered performance observer</a>
-            whose <a>observer</a> is the <a data-cite=
-            "WHATWG-DOM#context-object">context object</a>, replace its
+            whose <a>observer</a> is the <a>context object</a>, replace its
             <a>options list</a> with a list containing <var>options</var> as its
             only item.</li>
             <li>Otherwise, create and append a <a>registered performance
             observer</a> object to the <a>list of registered performance
             observer objects</a> of <var>relevantGlobal</var>, with
-            <a>observer</a> set to the <a data-cite="WHATWG-DOM#context-object">
-            context object</a> and <a>options list</a> set to a list containing
-            <var>options</var> as its only item.</li>
+            <a>observer</a> set to the <a>context object</a> and <a>options list</a>
+            set to a list containing <var>options</var> as its only item.</li>
           </ol>
           </li>
           <li>Otherwise, run the following steps:
@@ -446,8 +440,7 @@
             happens, for instance via a console warning.</li>
             <li>If the <a>list of registered performance observer objects</a> of
             <var>relevantGlobal</var> contains a <a>registered performance observer</a>
-            <var>obs</var> whose <a>observer</a> is the <a data-cite=
-            "WHATWG-DOM#context-object">context object</a>:
+            <var>obs</var> whose <a>observer</a> is the <a>context object</a>:
               <ol>
                 <li>If <var>obs</var>'s <a>options list</a> contains a
                 <a>PerformanceObserverInit</a> item <var>currentOptions</var>
@@ -462,9 +455,8 @@
             <a>registered performance observer</a> object to the <a>list of
             registered performance observer objects</a> of
             <var>relevantGlobal</var>, with <a>observer</a> set to the
-            <a data-cite="WHATWG-DOM#context-object">context object</a> and
-            <a>options list</a> set to a list containing <var>options</var>
-            as its only item.</li>
+            <a>context object</a> and <a>options list</a> set to a list
+            containing <var>options</var> as its only item.</li>
             <li>If <var>options</var>'s <a>buffered</a> flag is set:
               <ol>
                 <li>
@@ -472,8 +464,7 @@
                   tuple</a> given <var>options</var>'s <a>type</a> as
                   <var>entryType</var>.</li>
                 <li>For each <var>entry</var> in <var>tuple</var>'s
-                  <a>performance entry buffer</a>
-                  <a data-cite="WHATWG-INFRA#list-append">append</a>
+                  <a>performance entry buffer</a> <a data-xref-for="list">append</a>
                   <var>entry</var> to the <a>observer buffer</a>.</li>
                </ol>
             </li>
@@ -540,16 +531,14 @@
           <section>
             <h2><dfn>getEntries()</dfn> method</h2>
             <p>Returns a <a>PerformanceEntryList</a> object returned by
-            <a>filter buffer by name and type</a> algorithm with the <a 
-            data-cite="WHATWG-DOM#context-object">context object</a>'s
+            <a>filter buffer by name and type</a> algorithm with the <a>context object</a>'s
             <a>observer buffer</a>, <var>name</var> and <var>type</var> set to
             <code>null</code>.</p>
           </section>
           <section>
             <h2><dfn>getEntriesByType()</dfn> method</h2>
             <p>Returns a <a>PerformanceEntryList</a> object returned by
-            <a>filter buffer by name and type</a> algorithm with the <a 
-            data-cite="WHATWG-DOM#context-object">context object</a>'s
+            <a>filter buffer by name and type</a> algorithm with the <a>context object</a>'s
             <a>observer buffer</a>, <var>name</var> set to <code>null</code>,
             and <var>type</var> set to the method's input <code>type</code>
             parameter.</p>
@@ -557,8 +546,8 @@
           <section>
             <h2><dfn>getEntriesByName()</dfn> method</h2>
             <p>Returns a <a>PerformanceEntryList</a> object returned by
-            <a>filter buffer by name and type</a> algorithm with the <a 
-            data-cite="WHATWG-DOM#context-object">context object</a>'s
+            <a>filter buffer by name and type</a> algorithm with the <a
+           >context object</a>'s
             <a>observer buffer</a>, <var>name</var> set to the method input
             <code>name</code> parameter, and <var>type</var> set to
             <code>null</code> if optional `entryType` is omitted, or set to the
@@ -569,19 +558,14 @@
       <section>
         <h2><dfn>takeRecords()</dfn> method</h2>
         <p>The <a>takeRecords()</a> method must return a copy of the
-        <a data-cite="WHATWG-DOM#context-object">context object</a>'s
-        <a>observer buffer</a>, and also empty <a data-cite=
-        "WHATWG-DOM#context-object">context object</a>'s <a>observer
-        buffer</a>.</p>
+        <a>context object</a>'s <a>observer buffer</a>, and also empty
+        <a>context object</a>'s <a>observer buffer</a>.</p>
       </section>
       <section>
         <h2><dfn>disconnect()</dfn> method</h2>
-        <p>The <a>disconnect()</a> method must remove the <a data-cite=
-        "WHATWG-DOM#context-object">context object</a> from the <a>list of
-        registered performance observer objects</a> of <a data-cite=
-        "HTML/webappapis.html#concept-relevant-global">relevant global
-        object</a>, and also empty <a data-cite=
-        "WHATWG-DOM#context-object">context object</a>'s <a>observer
+        <p>The <a>disconnect()</a> method must remove the <a>context object</a> from the <a>list of
+        registered performance observer objects</a> of <a>relevant global
+        object</a>, and also empty <a>context object</a>'s <a>observer
         buffer</a>.</p>
       </section>
       <section>
@@ -611,7 +595,7 @@
     <h2>Processing</h2>
     <section data-link-for="PerformanceObserver">
       <h2>Queue a <code>PerformanceEntry</code></h2>
-      <p>To <dfn>queue a PerformanceEntry</dfn> (<var>new entry</var>), 
+      <p>To <dfn>queue a PerformanceEntry</dfn> (<var>new entry</var>),
       run these steps:</p>
       <ol>
         <li>Let <var>interested observers</var> be an initially empty set of
@@ -642,7 +626,7 @@
           Call the <a>determine eligibility for adding a performance entry</a>
           algorithm with <var>tuple</var> set to the <a>relevant performance
           entry tuple</a> given <var>entryType</var>.  If it returns true,
-          <a data-cite="WHATWG-INFRA#list-append">append</a> <var>new entry
+          <a data-xref-for="list">append</a> <var>new entry
           </var> to <var>tuple</var>'s <a>performance entry buffer</a>.</li>
         <li>If the <a>performance observer task queued flag</a> is set,
         terminate these steps.
@@ -650,18 +634,15 @@
         <li>Set <a>performance observer task queued flag</a>.
         </li>
         <li>
-          <a data-cite="HTML/webappapis.html#queue-a-task">Queue a task</a>
-          that consists of running the following substeps. The <a data-cite=
-          "HTML/webappapis.html#task-source">task source</a> for the queued
+           <a>Queue a task</a>
+          that consists of running the following substeps. The <a>task source</a> for the queued
           task is the <i>performance timeline</i> task source.
           <ol>
             <li>Unset <a>performance observer task queued flag</a> for the
-            <a data-cite=
-            "HTML/webappapis.html#concept-relevant-global">relevant global
+            <a>relevant global
             object</a>.
             </li>
-            <li>Let <var>notify list</var> be a copy of <a data-cite=
-            "HTML/webappapis.html#concept-relevant-global">relevant global
+            <li>Let <var>notify list</var> be a copy of <a>relevant global
             object</a>'s <a>list of registered performance observer
             objects</a>.
             </li>
@@ -675,19 +656,15 @@
                 </li>
                 <li>If <var>entries</var> is non-empty, call <var>po</var>’s callback
                 with <var>entries</var> as first argument and <var>po</var> as the
-                second argument and <a data-cite=
-                "WebIDL#dfn-callback-this-value">callback this value</a>. If
-                this <a data-cite="WebIDL#dfn-throw">throw</a>s an exception,
-                <a data-cite="HTML/webappapis.html#report-the-exception">report
-                the exception</a>.
+                second argument and <a>callback this value</a>. If
+                this <a>throw</a>s an exception, <a>report the exception</a>.
                 </li>
               </ol>
             </li>
           </ol>
         </li>
       </ol>
-      <p>The <i>performance timeline</i> <a data-cite=
-      "HTML/webappapis.html#task-queue">task queue</a> is a low priority queue
+      <p>The <i>performance timeline</i> <a>task queue</a> is a low priority queue
       that, if possible, should be processed by the user agent during idle
       periods to minimize impact of performance monitoring code.</p>
     </section>
@@ -697,21 +674,20 @@
       algorithm with optional <var>name</var> and <var>type</var>, run the
       following steps:</p>
       <ol>
-        <li>Let <var>result</var> be an initially empty <a
-        data-cite="WHATWG-INFRA#list">list</a>.</li>
+        <li>Let <var>result</var> be an initially empty
+        <a>list</a>.</li>
         <li>Let <var>map</var> be the <a>performance entry buffer map</a>
-        associated with the <a
-        data-cite="HTML/webappapis.html#concept-relevant-global">relevant
-        global object</a> of <a
-        data-cite="DOM#context-object">context object</a>.</li>
-        <li>Let <var>tuple list</var> be an empty <a
-        data-cite="WHATWG-INFRA#list">list</a>.</li>
-        <li>If <var>type</var> is not null, append the result of <a
-        data-cite="WHATWG-INFRA#map-get">getting the value of entry</a> on
-        <var>map</var> given <var>type</var> as <a
-        data-cite="WHATWG-INFRA#map-key">key</a> to <var>tuple list</var>.
-        Otherwise, assign the result of <a
-        data-cite="WHATWG-INFRA#map-getting-the-values">get the values</a> on <var>map</var> to
+        associated with the
+        <a>relevant
+        global object</a> of <a>context object</a>.</li>
+        <li>Let <var>tuple list</var> be an empty
+        <a>list</a>.</li>
+        <li>If <var>type</var> is not null, append the result of
+        <a>getting the value of entry</a> on
+        <var>map</var> given <var>type</var> as
+        <a>key</a> to <var>tuple list</var>.
+        Otherwise, assign the result of
+        <a>get the values</a> on <var>map</var> to
         <var>tuple list</var></li>
         <li>For each <var>tuple</var> in <var>tuple list</var>, run the
         following steps:
@@ -723,8 +699,8 @@
             <li>Let <var>entries</var> be the result of running <a>filter
             buffer by name and type</a> with <var>buffer</var>, <var>name</var>
             and <var>type</var> as inputs.</li>
-            <li>For each <var>entry</var> in <var>entries</var>, <a
-            data-cite="WHATWG-INFRA#list-append">append</a> <var>entry</var> to
+            <li>For each <var>entry</var> in <var>entries</var>,
+            <a data-xref-for="list">append</a> <var>entry</var> to
             <var>result</var>.</li>
           </ol>
         </li>
@@ -739,20 +715,18 @@
       algorithm, with <var>buffer</var>, <var>name</var>, and <var>type</var>
       as inputs, run the following steps:</p>
       <ol>
-        <li>Let <var>result</var> be an initially empty <a
-        data-cite="WHATWG-INFRA#list">list</a>.</li>
+        <li>Let <var>result</var> be an initially empty
+        <a>list</a>.</li>
         <li>For each <a>PerformanceEntry</a> <var>entry</var> in
         <var>buffer</var>, run the following steps:
           <ol>
             <li>If <var>type</var> is not null and if <var>type</var> does
             not match <var>entry</var>'s <code>entryType</code> attribute in a
-            <a data-cite="HTML/infrastructure.html#case-sensitive">case-sensitive</a>
-            manner, continue to next <var>entry</var>.</li>
+             <a>case-sensitive</a> manner, continue to next <var>entry</var>.</li>
             <li>If <var>name</var> is not null and if <var>name</var> does
             not match <var>entry</var>'s <code>name</code> attribute in a
-            <a data-cite="HTML/infrastructure.html#case-sensitive">case-sensitive</a>
-            manner, continue to next <var>entry</var>.</li>
-            <li><a data-cite="WHATWG-INFRA#list-append">Append</a>
+             <a>case-sensitive</a> manner, continue to next <var>entry</var>.</li>
+            <li><a data-xref-for="list">append</a>
             <var>entry</var> to <var>result</var>.</li>
           </ol>
         </li>
@@ -783,6 +757,25 @@
     <a>performance timeline</a>. Please refer to [[HR-TIME-2]] for privacy and
     security considerations of exposing high-resoluting timing information.</p>
   </section>
+  <section>
+    <h2>Dependencies</h2>
+    <p>The [[HR-TIME]] specification defines the <code><dfn data-cite=
+      "hr-time/#dom-domhighrestimestamp">DOMHighResTimeStamp</dfn></code> interface.</p>
+    <p>The [[INFRA]] specification defines the following:
+      <dfn data-cite="infra" data-xref-for="list">append</dfn>,
+      <dfn data-lt="keyed" data-cite="INFRA#map-key">key</dfn>,
+      <dfn data-cite="infra">value</dfn>,
+      <dfn data-lt="getting the value of entry"
+           data-cite="INFRA#map-get">getting the value of an entry</dfn>.
+    </p>
+    <p>The [[HTML]] specification defines the following:
+      <dfn data-cite="HTML/webappapis.html#task-queue">task queue</dfn>.</p>
+    <p>The [[WebIDL]] specification defines the following:
+      <code><dfn data-cite="WEBIDL#syntaxerror">SyntaxError</dfn></code>,
+      <dfn data-cite="WebIDL#es-environment">ECMAScript global environment</dfn>,
+      <code><dfn data-cite="WEBIDL#invalidmodificationerror">InvalidModificationError</dfn></code>.
+  </section>
+
   <section class="appendix" id="idl-index"></section>
   <section class="appendix">
     <h2>Acknowledgments</h2>


### PR DESCRIPTION
Now that we have a global entry names registry, the map of entrytype to buffer should be initialized with values from that table.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ehanley324/performance-timeline/pull/135.html" title="Last updated on Jun 25, 2019, 6:14 PM UTC (d2094cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/135/def3145...ehanley324:d2094cf.html" title="Last updated on Jun 25, 2019, 6:14 PM UTC (d2094cf)">Diff</a>