### PR TITLE
Fix link to availableFromTimeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,15 +210,12 @@
         <ul>
           <li>A <dfn>performance entry buffer</dfn> to store
             <a>PerformanceEntry</a> objects, that is initially empty.</li>
-          <li>A <a href="https://w3c.github.io/timing-entrytypes-registry/#registration">
-            <dfn>maxBufferSize</dfn></a>, initialized to the <a href=
+          <li>An integer <dfn>maxBufferSize</dfn>, initialized to the <a href=
             "https://w3c.github.io/timing-entrytypes-registry/#registry">registry</a>
             value for this entry type.</li>
-          <li>A <code>boolean</code> <a href=
-            "https://w3c.github.io/timing-entrytypes-registry/#registration">
-            availableFromTimeline</a>, initialized to the <a href=
-            "https://w3c.github.io/timing-entrytypes-registry/#registry">registry</a>
-            value for this entry type.</li>
+          <li>A <code>boolean</code> <dfn>availableFromTimeline</dfn>, initialized to the
+            <a href="https://w3c.github.io/timing-entrytypes-registry/#registry">
+            registry</a> value for this entry type.</li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
This PR adds a dfn to availableFromTimeline so that it links properly when referenced later. It changes to dfn only since there is already a link to the registry.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/pull/141.html" title="Last updated on Jul 8, 2019, 8:40 PM UTC (73a6069)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/141/4863a02...73a6069.html" title="Last updated on Jul 8, 2019, 8:40 PM UTC (73a6069)">Diff</a>