### PR TITLE
Give optional dictionary a default value of {}

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,7 +347,7 @@
                                                    PerformanceObserver observer);
       [Constructor(PerformanceObserverCallback callback), Exposed=(Window,Worker)]
       interface PerformanceObserver {
-        void observe (optional PerformanceObserverInit options);
+        void observe (optional PerformanceObserverInit options = {});
         void disconnect ();
         PerformanceEntryList takeRecords();
         [SameObject] static readonly attribute FrozenArray&lt;DOMString&gt; supportedEntryTypes;


### PR DESCRIPTION
Currently the rendered version of the spec (https://w3c.github.io/performance-timeline/) is complaining that optional dictionaries in Web IDL must have a default value of '{}'. This fixes that.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dsanders11/performance-timeline/pull/146.html" title="Last updated on Jul 17, 2019, 3:21 AM UTC (f1c66df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/146/8b7240a...dsanders11:f1c66df.html" title="Last updated on Jul 17, 2019, 3:21 AM UTC (f1c66df)">Diff</a>