### PR TITLE
Add default value to observe() parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,7 +347,7 @@
                                                    PerformanceObserver observer);
       [Constructor(PerformanceObserverCallback callback), Exposed=(Window,Worker)]
       interface PerformanceObserver {
-        void observe (optional PerformanceObserverInit options);
+        void observe (optional PerformanceObserverInit options = {});
         void disconnect ();
         PerformanceEntryList takeRecords();
         [SameObject] static readonly attribute FrozenArray&lt;DOMString&gt; supportedEntryTypes;


### PR DESCRIPTION
Due to the reSpec change, the IDL is underlined in red when the default parameter is not provided.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/pull/147.html" title="Last updated on Jul 24, 2019, 5:21 PM UTC (7ea4677)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/147/8b7240a...7ea4677.html" title="Last updated on Jul 24, 2019, 5:21 PM UTC (7ea4677)">Diff</a>