### PR TITLE
L2 branch: move constructor to a method

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,8 +320,9 @@
       <pre class="idl">
       callback PerformanceObserverCallback = void (PerformanceObserverEntryList entries,
                                                    PerformanceObserver observer);
-      [Constructor(PerformanceObserverCallback callback), Exposed=(Window,Worker)]
+      [Exposed=(Window,Worker)]
       interface PerformanceObserver {
+        constructor(PerformanceObserverCallback callback);
         void observe (PerformanceObserverInit options);
         void disconnect ();
         PerformanceEntryList takeRecords();


### PR DESCRIPTION
This prevents ReSpec from highlighting in red the whole WebIDL content.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/pull/152.html" title="Last updated on Oct 9, 2019, 7:36 PM UTC (ebf7567)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/152/d557fb0...ebf7567.html" title="Last updated on Oct 9, 2019, 7:36 PM UTC (ebf7567)">Diff</a>