### PR TITLE
Level2: more ReSpec fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
       testSuiteURI:
         "https://github.com/web-platform-tests/wpt/tree/master/performance-timeline",
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/45211/status",
+      xref: ["hr-time-2"]
     };
   </script>
 </head>
@@ -323,7 +324,7 @@
       [Exposed=(Window,Worker)]
       interface PerformanceObserver {
         constructor(PerformanceObserverCallback callback);
-        void observe (PerformanceObserverInit options);
+        void observe (optional PerformanceObserverInit options = {});
         void disconnect ();
         PerformanceEntryList takeRecords();
         [SameObject] static readonly attribute FrozenArray&lt;DOMString&gt; supportedEntryTypes;


### PR DESCRIPTION
Fixes https://github.com/w3c/performance-timeline/issues/153 To avoid having ReSpec red errors in WebIDL, this PR does two changes:
* Make the dictionary optional and add a default value to it (matches the master branch declaration)
* Add xref to hr-time-2 so that DOMHighResTimeStamp is found


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/pull/155.html" title="Last updated on Oct 18, 2019, 3:09 PM UTC (f9242ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/155/e247ab2...f9242ae.html" title="Last updated on Oct 18, 2019, 3:09 PM UTC (f9242ae)">Diff</a>