### PR TITLE
Remove unused [hr-time] reference.

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
         "check-punctuation": true,
       },
       doJsonLd: true,
-      xref: ["hr-time", "hr-time-2", "infra", "html", "dom"],
+      xref: ["hr-time-2", "infra", "html", "dom"],
       mdn: true,
     };
   </script>
@@ -322,7 +322,7 @@
         "https://w3c.github.io/timing-entrytypes-registry/#registry">registry</a>.
         Examples include: <code>"mark"</code> and <code>"measure"</code>
         [[USER-TIMING-2]], <code>"navigation"</code> [[NAVIGATION-TIMING-2]],
-        <code>"resource"</code> [[RESOURCE-TIMING-2]], 
+        <code>"resource"</code> [[RESOURCE-TIMING-2]],
         <!-- TODO: add long task spec reference -->
          and <code>"longtask"</code>.</p>
       </dd>


### PR DESCRIPTION
This led to a confusing entry in the references section that claimed to
point to the 2012 REC, but the https://www.w3.org/TR/hr-time/ URL
redirected to the 2019 PR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/performance-timeline/pull/156.html" title="Last updated on Dec 6, 2019, 5:54 PM UTC (18f7beb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/156/30ddab4...jyasskin:18f7beb.html" title="Last updated on Dec 6, 2019, 5:54 PM UTC (18f7beb)">Diff</a>