### PR TITLE
Fix observe() with buffered flag

### DIFF
--- a/index.html
+++ b/index.html
@@ -501,6 +501,7 @@
                 <li>For each <var>entry</var> in <var>tuple</var>'s
                 <a>performance entry buffer</a> [=list/append=]
                 <var>entry</var> to the <a>observer buffer</a>.
+                <li><a>Queue the PerformanceObserver task</a>.</li>
                 </li>
               </ol>
             </li>
@@ -670,6 +671,14 @@
         [=list/append=] <var>newEntry</var> to <var>tuple</var>'s
         <a>performance entry buffer</a>.
         </li>
+        <li><a>Queue the PerformanceObserver task</a>.</li>
+      </ol>
+    </section>
+    <section data-link-for="PerformanceObserver">
+      <h2>Queue the PerformanceObserver task</h2>
+      <p>When asked to <dfn>queue the PerformanceObserver task</dfn>, run the
+      following steps:</p>
+      <ol>
         <li>If the <a>performance observer task queued flag</a> is set,
         terminate these steps.
         </li>

--- a/index.html
+++ b/index.html
@@ -500,9 +500,9 @@
                 </li>
                 <li>For each <var>entry</var> in <var>tuple</var>'s
                 <a>performance entry buffer</a> [=list/append=]
-                <var>entry</var> to the <a>observer buffer</a>.
-                <li><a>Queue the PerformanceObserver task</a>.</li>
-                </li>
+                <var>entry</var> to the <a>observer buffer</a>.</li>
+                <li><a>Queue the PerformanceObserver task</a> with
+                <var>relevantGlobal</var> as input.</li>
               </ol>
             </li>
           </ol>
@@ -671,18 +671,20 @@
         [=list/append=] <var>newEntry</var> to <var>tuple</var>'s
         <a>performance entry buffer</a>.
         </li>
-        <li><a>Queue the PerformanceObserver task</a>.</li>
+        <li><a>Queue the PerformanceObserver task</a> with
+        <var>relevantGlobal</var> as input.</li>
       </ol>
     </section>
     <section data-link-for="PerformanceObserver">
       <h2>Queue the PerformanceObserver task</h2>
-      <p>When asked to <dfn>queue the PerformanceObserver task</dfn>, run the
-      following steps:</p>
+      <p>When asked to <dfn>queue the PerformanceObserver task</dfn>, given
+      <var>relevantGlobal</var> as input, run the following steps:</p>
       <ol>
-        <li>If the <a>performance observer task queued flag</a> is set,
-        terminate these steps.
+        <li>If <var>relevantGlobal</var>'s <a>performance observer task queued
+        flag</a> is set, terminate these steps.
         </li>
-        <li>Set <a>performance observer task queued flag</a>.
+        <li>Set <var>relevantGlobal</var>'s <a>performance observer task queued
+        flag</a>.
         </li>
         <li>
           <a>Queue a task</a> that consists of running the following substeps.


### PR DESCRIPTION
Fixes https://github.com/w3c/performance-timeline/issues/158. This PR fixes observe() so that the task that dispatched PerformanceObserver callbacks is queued whenever the buffered flag is used. This lets an observer receive buffered entries even if no other entries are later queued into the performance timeline.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/pull/159.html" title="Last updated on Jan 27, 2020, 4:34 PM UTC (013271a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/159/a20b0ac...013271a.html" title="Last updated on Jan 27, 2020, 4:34 PM UTC (013271a)">Diff</a>