### PR TITLE
Do not use SyntaxError

### DIFF
--- a/index.html
+++ b/index.html
@@ -394,10 +394,10 @@
         global object</a>.
         </li>
         <li>If <var>options</var>'s <a>entryTypes</a> and <a>type</a> members
-        are both omitted, then [=exception/throw=] a {{"SyntaxError"}}.
+        are both omitted, then [=exception/throw=] a {{"TypeError"}}.
         </li>
         <li>If <var>options</var>'s <a>entryTypes</a> is present and any other
-        member is also present, then [=exception/throw=] a {{"SyntaxError"}}.
+        member is also present, then [=exception/throw=] a {{"TypeError"}}.
         </li>
         <li>Update or check <var>observer</var>'s <a>observer type</a> by
         running these steps:


### PR DESCRIPTION
Fixes https://github.com/w3c/performance-timeline/issues/163


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/pull/164.html" title="Last updated on Apr 9, 2020, 9:37 PM UTC (5fb5262)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/164/87609bc...5fb5262.html" title="Last updated on Apr 9, 2020, 9:37 PM UTC (5fb5262)">Diff</a>