### PR TITLE
Add dfn to performance timeline task source

### DIFF
--- a/index.html
+++ b/index.html
@@ -717,8 +717,8 @@
         </li>
         <li>
           <a>Queue a task</a> that consists of running the following substeps.
-          The <a>task source</a> for the queued task is the <i>performance
-          timeline</i> task source.
+          The <a>task source</a> for the queued task is the <dfn data-export="">performance
+          timeline task source</dfn>.
           <ol>
             <li>Unset <a>performance observer task queued flag</a> of
             <var>relevantGlobal</var>.


### PR DESCRIPTION
This enables linking to it from other specifications. In particular this will be used in ResourceTiming for the buffer full task: https://github.com/w3c/resource-timing/issues/215


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/pull/175.html" title="Last updated on Sep 15, 2020, 1:29 PM UTC (318355d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/175/24bad8b...318355d.html" title="Last updated on Sep 15, 2020, 1:29 PM UTC (318355d)">Diff</a>