### PR TITLE
Remove context object

### DIFF
--- a/index.html
+++ b/index.html
@@ -411,7 +411,7 @@
       <p>The <a>observe()</a> method instructs the user agent to <dfn>register
       the observer</dfn> and must run these steps:</p>
       <ol data-link-for="PerformanceObserverInit">
-        <li>Let <var>observer</var> be the <a>context object</a>.
+        <li>Let <var>observer</var> be <a>this</a>.
         </li>
         <li>Let <var>relevantGlobal</var> be <var>observer</var>'s <a>relevant
         global object</a>.
@@ -469,14 +469,14 @@
             appropriate.</li>
             <li>If the <a>list of registered performance observer objects</a>
             of <var>relevantGlobal</var> contains a <a>registered performance
-            observer</a> whose <a>observer</a> is the <a>context object</a>,
+            observer</a> whose <a>observer</a> is <var>observer</var>,
             replace its <a>options list</a> with a list containing
             <var>options</var> as its only item.
             </li>
             <li>Otherwise, create and append a <a>registered performance
             observer</a> object to the <a>list of registered performance
             observer objects</a> of <var>relevantGlobal</var>, with
-            <a>observer</a> set to the <a>context object</a> and <a>options
+            <a>observer</a> set to <var>observer</var> and <a>options
             list</a> set to a list containing <var>options</var> as its only
             item.
             </li>
@@ -494,8 +494,7 @@
             </li>
             <li>If the <a>list of registered performance observer objects</a>
             of <var>relevantGlobal</var> contains a <a>registered performance
-            observer</a> <var>obs</var> whose <a>observer</a> is the <a>context
-            object</a>:
+            observer</a> <var>obs</var> whose <a>observer</a> is <var>observer</var>:
               <ol>
                 <li>If <var>obs</var>'s <a>options list</a> contains a
                 <a>PerformanceObserverInit</a> item <var>currentOptions</var>
@@ -511,7 +510,7 @@
             <li>Otherwise, create and append a <a>registered performance
             observer</a> object to the <a>list of registered performance
             observer objects</a> of <var>relevantGlobal</var>, with
-            <a>observer</a> set to the <a>context object</a> and <a>options
+            <a>observer</a> set to the <var>observer</var> and <a>options
             list</a> set to a list containing <var>options</var> as its only
             item.
             </li>
@@ -599,43 +598,40 @@
         <section>
           <h2><dfn>getEntries()</dfn> method</h2>
           <p>Returns a <a>PerformanceEntryList</a> object returned by <a>filter
-          buffer by name and type</a> algorithm with the <a>context
-          object</a>'s <a>entry list</a>, <var>name</var> and
-          <var>type</var> set to <code>null</code>.</p>
+          buffer by name and type</a> algorithm with <a>this</a>'s <a>entry list</a>,
+          <var>name</var> and <var>type</var> set to <code>null</code>.</p>
         </section>
         <section>
           <h2><dfn>getEntriesByType()</dfn> method</h2>
           <p>Returns a <a>PerformanceEntryList</a> object returned by <a>filter
-          buffer by name and type</a> algorithm with the <a>context
-          object</a>'s <a>entry list</a>, <var>name</var> set to
-          <code>null</code>, and <var>type</var> set to the method's input
-          <code>type</code> parameter.</p>
+          buffer by name and type</a> algorithm with <a>this</a>'s <a>entry list</a>,
+          <var>name</var> set to <code>null</code>, and <var>type</var> set to the
+          method's input <code>type</code> parameter.</p>
         </section>
         <section>
           <h2><dfn>getEntriesByName()</dfn> method</h2>
           <p>Returns a <a>PerformanceEntryList</a> object returned by <a>filter
-          buffer by name and type</a> algorithm with the <a>context
-          object</a>'s <a>entry list</a>, <var>name</var> set to the
-          method input <code>name</code> parameter, and <var>type</var> set to
-          <code>null</code> if optional `entryType` is omitted, or set to the
-          method's input <code>type</code> parameter otherwise.</p>
+          buffer by name and type</a> algorithm with <a>this</a>'s <a>entry list</a>,
+          <var>name</var> set to the method input <code>name</code> parameter, and
+          <var>type</var> set to <code>null</code> if optional `entryType` is omitted,
+          or set to the method's input <code>type</code> parameter otherwise.</p>
         </section>
       </section>
     </section>
     <section>
       <h2><dfn>takeRecords()</dfn> method</h2>
-      <p>The <a>takeRecords()</a> method must return a copy of the <a>context
-      object</a>'s <a>observer buffer</a>, and also empty <a>context
-      object</a>'s <a>observer buffer</a>.</p>
+      <p>The <a>takeRecords()</a> method must return a copy of <a>this</a>'s
+      <a>observer buffer</a>, and also empty <a>this</a>'s <a>observer
+      buffer</a>.</p>
     </section>
     <section>
       <h2><dfn>disconnect()</dfn> method</h2>
       <p>The <a>disconnect()</a> method must do the following:</p>
       <ol>
-        <li>Remove the <a>context object</a> from the <a>list of registered
+        <li>Remove <a>this</a> from the <a>list of registered
         performance observer objects</a> of <a>relevant global object</a>.</li>
-        <li>Empty the <a>context object</a>'s <a>observer buffer</a>.</li>
-        <li>Empty the <a>context object</a>'s <a>options list</a>.</li>
+        <li>Empty <a>this</a>'s <a>observer buffer</a>.</li>
+        <li>Empty <a>this</a>'s <a>options list</a>.</li>
       </ol>
     </section>
     <section>
@@ -808,8 +804,7 @@
         <li>Let <var>result</var> be an initially empty <a>list</a>.
         </li>
         <li>Let <var>map</var> be the <a>performance entry buffer map</a>
-        associated with the <a>relevant global object</a> of <a>context
-        object</a>.
+        associated with the <a>relevant global object</a> of <a>this</a>.
         </li>
         <li>Let <var>tuple list</var> be an empty <a>list</a>.
         </li>


### PR DESCRIPTION
It seems `context object` is deprecated, in favor of `this`.