### PR TITLE
Add navigationId to PerformanceEntry

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -59,6 +59,8 @@ The entry has the following attributes:
 * `entryType`: a string representing the type of performance data being exposed. It is also used to filter entries in the `getEntriesByType()` method and in the `PerformanceObserver`.
 * `startTime`: a timestamp representing the starting point for the performance data being recorded. The semantics of this attribute depend on the `entryType`.
 * `duration`: a time duration representing the duration of the performance data being recorded. The semantics of this one also depend on the `entryType`.
+* `navigationId`: an integer indicating how many times the user has navigated to this document
+since it was initially loaded.
 
 If these sound abstract, it’s because they are.
 A specification whose goal is to expose new measurements to web developers will define a new interface which extends `PerformanceEntry`.
@@ -149,6 +151,21 @@ Having both polling and callbacks has proved to be useful.
 For entryTypes with a fixed amount of entries, like Paint Timing, using the polling method is more convenient, especially in the current state of the world where analytics providers often only send a single beacon per page load.
 At the same time, the callback is more useful for cases where there is varying amount of entries of the given entryType, like in Resource Timing.
 The web performance monitoring service can process all the performance information while the page is still running and only has to do very minimal work when the data needs to be reported.
+
+## Page lifetime issues
+When this API was originally designed, documents had a relatively simple lifecycle: they were
+loaded when the user navigated to them, and unloaded when the user navigated away, with the
+JavaScript environment being torn down at that time. Since then, the sitution has become more
+complex, with many browsers introducing a back-forwards-cache, with which a user can return
+a document wich they have previously navigated away from. The web has also seen a rise in
+popularity of Single Page Apps, where what appears to the user to be a navigation is actually
+just a change in state of a running page. In both of these situations, a navigation (or what
+appears to the user as a navigation) can occur without the performance timeline being reset.
+In order to allow developers to reason about such events during the life of a page,
+PerformanceEntry objects now include a navigation counter field. This field captures the
+count of navigations which had occurred when the entry was generated (starting at 1 when the
+document is initially loaded, and being incremented by one with each subsequent navigation of
+the document.)
 
 # Standards Status
 The Performance Timeline specification is widely approved.

--- a/explainer.md
+++ b/explainer.md
@@ -59,8 +59,7 @@ The entry has the following attributes:
 * `entryType`: a string representing the type of performance data being exposed. It is also used to filter entries in the `getEntriesByType()` method and in the `PerformanceObserver`.
 * `startTime`: a timestamp representing the starting point for the performance data being recorded. The semantics of this attribute depend on the `entryType`.
 * `duration`: a time duration representing the duration of the performance data being recorded. The semantics of this one also depend on the `entryType`.
-* `navigationId`: an integer indicating how many times the user has navigated to this document
-since it was initially loaded.
+* `navigationId`: a string identifying the `PerformanceEntry` object corresponding to the last navigation or navigation-like event that had occurred in the document at the time that this `PerformanceEntry` object was recorded.
 
 If these sound abstract, it’s because they are.
 A specification whose goal is to expose new measurements to web developers will define a new interface which extends `PerformanceEntry`.
@@ -161,11 +160,10 @@ a document wich they have previously navigated away from. The web has also seen 
 popularity of Single Page Apps, where what appears to the user to be a navigation is actually
 just a change in state of a running page. In both of these situations, a navigation (or what
 appears to the user as a navigation) can occur without the performance timeline being reset.
-In order to allow developers to reason about such events during the life of a page,
-PerformanceEntry objects now include a navigation counter field. This field captures the
-count of navigations which had occurred when the entry was generated (starting at 1 when the
-document is initially loaded, and being incremented by one with each subsequent navigation of
-the document.)
+In order to allow developers to reason about such events during the life of a page, some
+PerformanceEntry objects mark navigations, or navigation-like events. All PerformanceEntry
+objects include a navigation ID field, which links each PerformanceEntry to the most recent
+navigation entry which had occurred when the entry was generated.
 
 # Standards Status
 The Performance Timeline specification is widely approved.

--- a/explainer.md
+++ b/explainer.md
@@ -55,11 +55,12 @@ In order to prevent the user agent from storing too much performance data in mem
 This specification defines the `PerformanceEntry` interface, which is used to host performance data of the web application.
 A single `PerformanceEntry` object corresponds to one nugget of information about the performance of the website.
 The entry has the following attributes:
+* `id`: an integer identifying this `PerformanceEntry` object.
 * `name`: a string identifier for the object, also used to filter entries in the `getEntriesByName()` method.
 * `entryType`: a string representing the type of performance data being exposed. It is also used to filter entries in the `getEntriesByType()` method and in the `PerformanceObserver`.
 * `startTime`: a timestamp representing the starting point for the performance data being recorded. The semantics of this attribute depend on the `entryType`.
 * `duration`: a time duration representing the duration of the performance data being recorded. The semantics of this one also depend on the `entryType`.
-* `navigationId`: a string identifying the `PerformanceEntry` object corresponding to the last navigation or navigation-like event that had occurred in the document at the time that this `PerformanceEntry` object was recorded.
+* `navigationId`: an integer identifying (by `id`)  the `PerformanceEntry` object corresponding to last navigation or navigation-like event that had occurred in the document at the time that this `PerformanceEntry` object was recorded.
 
 If these sound abstract, it’s because they are.
 A specification whose goal is to expose new measurements to web developers will define a new interface which extends `PerformanceEntry`.

--- a/explainer.md
+++ b/explainer.md
@@ -155,15 +155,15 @@ The web performance monitoring service can process all the performance informati
 When this API was originally designed, documents had a relatively simple lifecycle: they were
 loaded when the user navigated to them, and unloaded when the user navigated away, with the
 JavaScript environment being torn down at that time. Since then, the sitution has become more
-complex, with many browsers introducing a back-forwards-cache, with which a user can return
-a document wich they have previously navigated away from. The web has also seen a rise in
+complex, with many browsers introducing a back-forward cache, with which a user can return to
+a document which they have previously navigated away from. The web has also seen a rise in
 popularity of Single Page Apps, where what appears to the user to be a navigation is actually
 just a change in state of a running page. In both of these situations, a navigation (or what
 appears to the user as a navigation) can occur without the performance timeline being reset.
 In order to allow developers to reason about such events during the life of a page, some
 PerformanceEntry objects mark navigations, or navigation-like events. All PerformanceEntry
-objects include a navigation ID field, which links each PerformanceEntry to the most recent
-navigation entry which had occurred when the entry was generated.
+objects include a navigation ID field, which ties each PerformanceEntry to the most recent
+navigation entry which had occurred before the entry was generated.
 
 # Standards Status
 The Performance Timeline specification is widely approved.

--- a/index.html
+++ b/index.html
@@ -249,7 +249,6 @@
           <li>An integer <dfn>dropped entries count</dfn> that is initially 0.</li>
         </ul>
       </li>
-      <li>An integer <dfn>current navigation id</dfn> that is initially 0.</li>
     </ul>
     <p>In order to get the <dfn>relevant performance entry tuple</dfn>, given
     <var>entryType</var> and <var>globalObject</var> as input, run the
@@ -262,17 +261,6 @@
         map</var>, given <var>entryType</var> as the <a>key</a>.
       </li>
     </ol>
-    <p>The <a
-    href="https://html.spec.whatwg.org/#session-history-document-visibility-change-steps">session
-    history document visibility change steps</a> defined by this specification are:</p>
-    <ol>
-      <li>Increment <var>newDocument</var>'s [=relevant global object=]'s <a>current navigation
-      id</a>.</li>
-    </ol>
-    <p class="note">These steps will be called from [[HTML]]'s <a
-    href="https://html.spec.whatwg.org/#traverse-the-history">traverse the history</a>
-    algorithm whenever a document is restored from the bfcache, immediately before the
-    [=Window/pageshow=] event is fired.</p>
     <section data-dfn-for="Performance" data-link-for="Performance">
       <h2>Extensions to the {{Performance}} interface</h2>
       <p>This extends the {{Performance}} interface from [[HR-TIME-3]] and
@@ -362,9 +350,7 @@
       </dd>
       <dt><dfn>navigationId</dfn></dt>
       <dd>
-        This attribute MUST return the value of the global object's <a>current
-        navigation id</a> at the time that this <a>PerformanceEntry</a> was
-        queued.
+        This attribute MUST return the value of <a>this</a>'s <a>navigationId</a>.
       </dd>
     </dl>
     <p>When <dfn>toJSON</dfn> is called, run [[WebIDL]]'s <a>default toJSON
@@ -694,8 +680,17 @@
         <li>Let <var>relevantGlobal</var> be <var>newEntry</var>'s <a>relevant
         global object</a>.
         </li>
-        <li>Set <var>newEntry</var>'s <a data-lt="PerformanceEntry.navigationId">navigationId</a>
-        to <var>relevantGlobal</var>'s <a>current navigation id</a>.</li>
+        <li>If <var>relevantGlobal</var>'s <a>environment settings object</a> has a
+        [=environment settings object/responsible document=]:
+          <ol>
+            <li>Set <var>newEntry</var>'s <a
+            data-lt="PerformanceEntry.navigationId">navigationId</a> to the value of
+            <var>relevantGlobal</var>'s <a>environment settings object</a>'s [=environment
+            settings object/responsible document=]'s <a>navigation counter</a>.</li>
+          </ol>
+        </li>
+        <li>Otherwise, set <var>newEntry</var>'s <a
+        data-lt="PerformanceEntry.navigationId">navigationId</a> to 0.</li>
         <li>For each <a>registered performance observer</a> <var>regObs</var> in
         <var>relevantGlobal</var>'s <a>list of registered performance observer objects</a>:
           <ol>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
         "check-punctuation": true,
       },
       doJsonLd: true,
-      xref: ["hr-time-3", "infra", "html", "dom"],
+      xref: ["hr-time-3", "infra", "html", "dom", 'ecmascript'],
       mdn: "performance-timeline",
     };
   </script>
@@ -249,7 +249,7 @@
     </ul>
     <p>Each <a>Document</a> has:</p>
     <ul>
-      <li>a <dfn>most recent navigation</dfn>, which is a <a>PerformanceEntry</a>,
+      <li>A <dfn>most recent navigation</dfn>, which is a <a>PerformanceEntry</a>,
       initially unset.
       </li>
     </ul>
@@ -598,7 +598,6 @@
             PerformanceEntryList getEntries();
             PerformanceEntryList getEntriesByType (DOMString type);
             PerformanceEntryList getEntriesByName (DOMString name, optional DOMString type);
-            PerformanceEntryList getEntriesByNavigationId (DOMString navigationId);
           };
           </pre>
           <p>Each {{PerformanceObserverEntryList}} object has an associated
@@ -607,33 +606,23 @@
         <section>
           <h2><dfn>getEntries()</dfn> method</h2>
           <p>Returns a <a>PerformanceEntryList</a> object returned by <a>filter
-          buffer</a> algorithm with <a>this</a>'s <a>entry list</a>,
-          <var>name</var>, <var>type</var> and <var>navigationId</var> set to
-          <code>null</code>.</p>
+          buffer by name and type</a> algorithm with <a>this</a>'s <a>entry list</a>,
+          <var>name</var> and <var>type</var> set to <code>null</code>.</p>
         </section>
         <section>
           <h2><dfn>getEntriesByType()</dfn> method</h2>
           <p>Returns a <a>PerformanceEntryList</a> object returned by <a>filter
-          buffer</a> algorithm with <a>this</a>'s <a>entry list</a>,
-          <var>name</var> set to <code>null</code>, <var>type</var> set to the
-          method's input <code>type</code> parameter, and <var>navigationId</var>
-          set to <code>null</code>.</p>
+          buffer by name and type</a> algorithm with <a>this</a>'s <a>entry list</a>,
+          <var>name</var> set to <code>null</code>, and <var>type</var> set to the
+          method's input <code>type</code> parameter.</p>
         </section>
         <section>
           <h2><dfn>getEntriesByName()</dfn> method</h2>
           <p>Returns a <a>PerformanceEntryList</a> object returned by <a>filter
-          buffer</a> algorithm with <a>this</a>'s <a>entry list</a>,
+          buffer by name and type</a> algorithm with <a>this</a>'s <a>entry list</a>,
           <var>name</var> set to the method input <code>name</code> parameter, and
           <var>type</var> set to <code>null</code> if optional `entryType` is omitted,
           or set to the method's input <code>type</code> parameter otherwise.</p>
-        </section>
-        <section>
-          <h2><dfn>getEntriesByNavigationId()</dfn> method</h2>
-          <p>Returns a <a>PerformanceEntryList</a> object returned by <a>filter
-          buffer</a> algorithm with <a>this</a>'s <a>entry list</a>,
-          <var>name</var> and <var>type</var> set to <code>null</code>, and
-          <var>navigationId</var> set to the method's input
-          <code>navigationId</code> parameter.</p>
         </section>
       </section>
     </section>
@@ -878,7 +867,7 @@
             continue to the next <var>tuple</var>.
             </li>
             <li>Let <var>entries</var> be the result of running <a>filter
-            buffer</a> with <var>buffer</var>, <var>name</var>
+            buffer by name and type</a> with <var>buffer</var>, <var>name</var>
             and <var>type</var> as inputs.
             </li>
             <li>For each <var>entry</var> in <var>entries</var>,
@@ -892,10 +881,10 @@
       </ol>
     </section>
     <section data-link-for="PerformanceEntry">
-      <h2>Filter buffer</h2>
-      <p>When asked to run the <dfn>filter buffer</dfn>
-      algorithm, with <var>buffer</var>, <var>name</var>, <var>type</var>, and
-      <var>navigationId</var> as inputs, run the following steps:</p>
+      <h2>Filter buffer by name and type</h2>
+      <p>When asked to run the <dfn>filter buffer by name and type</dfn>
+      algorithm, with <var>buffer</var>, <var>name</var>, and <var>type</var>
+      as inputs, run the following steps:</p>
       <ol>
         <li>Let <var>result</var> be an initially empty <a>list</a>.
         </li>
@@ -909,12 +898,6 @@
             <li>If <var>name</var> is not null and if <var>name</var> is not
             <a data-cite=INFRA#string-is>identical to</a> <var>entry</var>'s
             <code>name</code> attribute, continue to next <var>entry</var>.
-            </li>
-            <li>If <var>navigationId</var> is not null and if
-            <var>navigationId</var> is not
-            <a data-cite=INFRA#string-is>identical to</a> <var>entry</var>'s
-            <code>navigationId</code> attribute, continue to next
-            <var>entry</var>.
             </li>
             <li>[=list/append=] <var>entry</var> to <var>result</var>.</li>
           </ol>
@@ -948,9 +931,21 @@
       <ol>
         <li>Let <var>type</var> be <var>entry</var>'s <a>entryType</a>.</li>
         <li>Let <var>startTime</var> be <var>entry</var>'s <a>startTime</a>.
+        <li>Let <var>timeString</var> be the result of calling
+        {{Number/toString(radix)}}(<var>startTime</var>, 10).
+        </li>
+        <li>If <var>timeString</var> contains the code point U+002E FULL STOP:
+          <ol>
+            <li><a>Assert</a>: <var>timeString</var> contains only one instance
+            of U+002E FULL STOP.</li>
+            <li><a>Assert</a>: <var>timeString</var> contains at least one code
+            point following the U+002E FULL STOP code point.</li>
+            <li>Truncate <var>timeString</var> after the first code point
+            following the U+002E FULL STOP code point.</li>
+          </ol>
         </li>
         <li>Return the [=string/concatenation=] of « <var>type</var>,
-        <var>time</var> » using U+002D HYPHEN-MINUS.</li>
+        <var>timeString</var> » using U+002D HYPHEN-MINUS.</li>
       </ol>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -678,13 +678,11 @@
         <li>Let <var>relevantGlobal</var> be <var>newEntry</var>'s <a>relevant
         global object</a>.
         </li>
-        <li>If <var>relevantGlobal</var>'s <a>environment settings object</a> has a
-        [=environment settings object/responsible document=]:
+        <li>If <var>relevantGlobal</var> has an [=associated document=]:
           <ol>
             <li>Set <var>newEntry</var>'s <a
             data-lt="PerformanceEntry.navigationId">navigationId</a> to the value of
-            <var>relevantGlobal</var>'s <a>environment settings object</a>'s [=environment
-            settings object/responsible document=]'s <a>navigation counter</a>.</li>
+            <var>relevantGlobal</var>'s [=associated document=]'s [=navigation id=].</li>
           </ol>
         </li>
         <li>Otherwise, set <var>newEntry</var>'s <a
@@ -903,6 +901,19 @@
         <li>Return true.</li>
       </ol>
     </section>
+  </section>
+  <section>
+    <h3>Integration with HTML</h3>
+    <p class="note">This section defines concepts which should rightly be defined in
+      [[HTML]]. Remove this section once those definitions exist there.</p>
+    <p>A [=Document=] has a <dfn>navigation id</dfn> which is an integer. It is
+      initially 0.</p>
+    <p>In [[HTML#history-traversal]], in the [[HTML#traverse-the-history]]
+      algorithm, add the following line after step 4.7.2:
+      <ol>
+        <li>Increment <var>newDocument</var>'s [=navigation id=].</li>
+      </ol>
+    </p>
   </section>
   <section id="privacy">
     <h3>Privacy Considerations</h3>

--- a/index.html
+++ b/index.html
@@ -247,6 +247,12 @@
         </ul>
       </li>
     </ul>
+    <p>Each <a>Document</a> has:</p>
+    <ul>
+      <li>a <dfn>most recent navigation</dfn>, which is a <a>PerformanceEntry</a>,
+      initially unset.
+      </li>
+    </ul>
     <p>In order to get the <dfn>relevant performance entry tuple</dfn>, given
     <var>entryType</var> and <var>globalObject</var> as input, run the
     following steps:</p>
@@ -308,7 +314,7 @@
         readonly    attribute DOMString           entryType;
         readonly    attribute DOMHighResTimeStamp startTime;
         readonly    attribute DOMHighResTimeStamp duration;
-        readonly    attribute unsigned long       navigationId;
+        readonly    attribute DOMString           navigationId;
         [Default] object toJSON();
       };</pre>
     <dl>
@@ -592,6 +598,7 @@
             PerformanceEntryList getEntries();
             PerformanceEntryList getEntriesByType (DOMString type);
             PerformanceEntryList getEntriesByName (DOMString name, optional DOMString type);
+            PerformanceEntryList getEntriesByNavigationId (DOMString navigationId);
           };
           </pre>
           <p>Each {{PerformanceObserverEntryList}} object has an associated
@@ -600,23 +607,33 @@
         <section>
           <h2><dfn>getEntries()</dfn> method</h2>
           <p>Returns a <a>PerformanceEntryList</a> object returned by <a>filter
-          buffer by name and type</a> algorithm with <a>this</a>'s <a>entry list</a>,
-          <var>name</var> and <var>type</var> set to <code>null</code>.</p>
+          buffer</a> algorithm with <a>this</a>'s <a>entry list</a>,
+          <var>name</var>, <var>type</var> and <var>navigationId</var> set to
+          <code>null</code>.</p>
         </section>
         <section>
           <h2><dfn>getEntriesByType()</dfn> method</h2>
           <p>Returns a <a>PerformanceEntryList</a> object returned by <a>filter
-          buffer by name and type</a> algorithm with <a>this</a>'s <a>entry list</a>,
-          <var>name</var> set to <code>null</code>, and <var>type</var> set to the
-          method's input <code>type</code> parameter.</p>
+          buffer</a> algorithm with <a>this</a>'s <a>entry list</a>,
+          <var>name</var> set to <code>null</code>, <var>type</var> set to the
+          method's input <code>type</code> parameter, and <var>navigationId</var>
+          set to <code>null</code>.</p>
         </section>
         <section>
           <h2><dfn>getEntriesByName()</dfn> method</h2>
           <p>Returns a <a>PerformanceEntryList</a> object returned by <a>filter
-          buffer by name and type</a> algorithm with <a>this</a>'s <a>entry list</a>,
+          buffer</a> algorithm with <a>this</a>'s <a>entry list</a>,
           <var>name</var> set to the method input <code>name</code> parameter, and
           <var>type</var> set to <code>null</code> if optional `entryType` is omitted,
           or set to the method's input <code>type</code> parameter otherwise.</p>
+        </section>
+        <section>
+          <h2><dfn>getEntriesByNavigationId()</dfn> method</h2>
+          <p>Returns a <a>PerformanceEntryList</a> object returned by <a>filter
+          buffer</a> algorithm with <a>this</a>'s <a>entry list</a>,
+          <var>name</var> and <var>type</var> set to <code>null</code>, and
+          <var>navigationId</var> set to the method's input
+          <code>navigationId</code> parameter.</p>
         </section>
       </section>
     </section>
@@ -681,11 +698,11 @@
           <ol>
             <li>Set <var>newEntry</var>'s <a
             data-lt="PerformanceEntry.navigationId">navigationId</a> to the value of
-            <var>relevantGlobal</var>'s [=associated document=]'s [=navigation id=].</li>
+            <var>relevantGlobal</var>'s [=associated document=]'s [=most recent navigation=]'s {{PerformanceEntry/navigationId}}.</li>
           </ol>
         </li>
         <li>Otherwise, set <var>newEntry</var>'s <a
-        data-lt="PerformanceEntry.navigationId">navigationId</a> to 0.</li>
+        data-lt="PerformanceEntry.navigationId">navigationId</a> to null.</li>
         <li>For each <a>registered performance observer</a> <var>regObs</var> in
         <var>relevantGlobal</var>'s <a>list of registered performance observer objects</a>:
           <ol>
@@ -729,6 +746,24 @@
         <li><a>Queue the PerformanceObserver task</a> with
         <var>relevantGlobal</var> as input.
         </li>
+      </ol>
+    </section>
+    <section data-link-for="PerformanceObserver">
+      <h2>Queue a navigation <code>PerformanceEntry</code></h2>
+      <p>To <dfn class="export">queue a navigation PerformanceEntry</dfn> (<var>newEntry</var>), run
+      these steps:</p>
+      <ol>
+        <li>Let <var>navigationId</var> be the result of running <a>generate a navigationId</a> for <var>newEntry</var>.</li>
+        <li>Let <var>relevantGlobal</var> be <var>newEntry</var>'s <a>relevant
+        global object</a>.
+        </li>
+        <li>Set <var>newEntry</var>'s {{PerformanceEntry/navigationId}} to <var>navigationId</var>.</li>
+        <li>If <var>relevantGlobal</var> has an [=associated document=]:
+          <ol>
+            <li>Set <var>relevantGlobal</var>'s [=associated document=]'s [=most recent navigation=] to <var>newEntry</var>.</li>
+          </ol>
+        </li>
+        <li><a>Queue a PerformanceEntry</a> with <var>newEntry</var> as input.</li>
       </ol>
     </section>
     <section data-link-for="PerformanceObserver">
@@ -843,7 +878,7 @@
             continue to the next <var>tuple</var>.
             </li>
             <li>Let <var>entries</var> be the result of running <a>filter
-            buffer by name and type</a> with <var>buffer</var>, <var>name</var>
+            buffer</a> with <var>buffer</var>, <var>name</var>
             and <var>type</var> as inputs.
             </li>
             <li>For each <var>entry</var> in <var>entries</var>,
@@ -857,10 +892,10 @@
       </ol>
     </section>
     <section data-link-for="PerformanceEntry">
-      <h2>Filter buffer by name and type</h2>
-      <p>When asked to run the <dfn>filter buffer by name and type</dfn>
-      algorithm, with <var>buffer</var>, <var>name</var>, and <var>type</var>
-      as inputs, run the following steps:</p>
+      <h2>Filter buffer</h2>
+      <p>When asked to run the <dfn>filter buffer</dfn>
+      algorithm, with <var>buffer</var>, <var>name</var>, <var>type</var>, and
+      <var>navigationId</var> as inputs, run the following steps:</p>
       <ol>
         <li>Let <var>result</var> be an initially empty <a>list</a>.
         </li>
@@ -874,6 +909,12 @@
             <li>If <var>name</var> is not null and if <var>name</var> is not
             <a data-cite=INFRA#string-is>identical to</a> <var>entry</var>'s
             <code>name</code> attribute, continue to next <var>entry</var>.
+            </li>
+            <li>If <var>navigationId</var> is not null and if
+            <var>navigationId</var> is not
+            <a data-cite=INFRA#string-is>identical to</a> <var>entry</var>'s
+            <code>navigationId</code> attribute, continue to next
+            <var>entry</var>.
             </li>
             <li>[=list/append=] <var>entry</var> to <var>result</var>.</li>
           </ol>
@@ -900,19 +941,18 @@
         <li>Return true.</li>
       </ol>
     </section>
-  </section>
-  <section>
-    <h3>Integration with HTML</h3>
-    <p class="note">This section defines concepts which should rightly be defined in
-      [[HTML]]. Remove this section once those definitions exist there.</p>
-    <p>A [=Document=] has a <dfn>navigation id</dfn> which is an integer. It is
-      initially 0.</p>
-    <p>In [[HTML#history-traversal]], in the [[HTML#traverse-the-history]]
-      algorithm, add the following line after step 4.7.2:
+    <section data-link-for="PerformanceEntry">
+      <h2>Generate a navigationId</h2>
+      <p>When asked to <dfn class="export">generate a navigationId</dfn> for a
+      <a>PerformanceEntry</a> <var>entry</a>, run the following steps:</p>
       <ol>
-        <li>Increment <var>newDocument</var>'s [=navigation id=].</li>
+        <li>Let <var>type</var> be <var>entry</var>'s <a>entryType</a>.</li>
+        <li>Let <var>startTime</var> be <var>entry</var>'s <a>startTime</a>.
+        </li>
+        <li>Return the [=string/concatenation=] of « <var>type</var>,
+        <var>time</var> » using U+002D HYPHEN-MINUS.</li>
       </ol>
-    </p>
+    </section>
   </section>
   <section id="privacy">
     <h3>Privacy Considerations</h3>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
         "check-punctuation": true,
       },
       doJsonLd: true,
-      xref: ["hr-time-3", "infra", "html", "dom", 'ecmascript'],
+      xref: ["hr-time-3", "infra", "html", "dom"],
       mdn: "performance-timeline",
     };
   </script>
@@ -246,6 +246,9 @@
           <li>An integer <dfn>dropped entries count</dfn> that is initially 0.</li>
         </ul>
       </li>
+      <li>An integer <dfn>last performance entry id</dfn> that is initially set
+      to a random integer between 100 and 10000.
+      </li>
     </ul>
     <p>Each <a>Document</a> has:</p>
     <ul>
@@ -310,14 +313,19 @@
     <pre class='idl'>
       [Exposed=(Window,Worker)]
       interface PerformanceEntry {
+        readonly    attribute unsigned long long  id;
         readonly    attribute DOMString           name;
         readonly    attribute DOMString           entryType;
         readonly    attribute DOMHighResTimeStamp startTime;
         readonly    attribute DOMHighResTimeStamp duration;
-        readonly    attribute DOMString           navigationId;
+        readonly    attribute unsigned long long  navigationId;
         [Default] object toJSON();
       };</pre>
     <dl>
+      <dt><dfn>id</dfn></dt>
+      <dd>
+        This attribute MUST return the value of <a>this</a>'s <a>id</a>.
+      </dd>
       <dt><dfn>name</dfn></dt>
       <dd>
         This attribute MUST return an identifier for this
@@ -674,6 +682,12 @@
       <p>To <dfn class="export">queue a PerformanceEntry</dfn> (<var>newEntry</var>), run
       these steps:</p>
       <ol>
+        <li>If <var>newEntry</var>'s {{PerformanceEntry/id}} is unset:
+          <ol>
+            <li>Let <var>id</var> be the result of running <a>generate an id</a> for <var>newEntry</var>.</li>
+            <li>Set <var>newEntry</var>'s {{PerformanceEntry/id}} to <var>id</var>.</li>
+          </ol>
+        </li>
         <li>Let <var>interested observers</var> be an initially empty set of
         <a>PerformanceObserver</a> objects.
         </li>
@@ -687,7 +701,7 @@
           <ol>
             <li>Set <var>newEntry</var>'s <a
             data-lt="PerformanceEntry.navigationId">navigationId</a> to the value of
-            <var>relevantGlobal</var>'s [=associated document=]'s [=most recent navigation=]'s {{PerformanceEntry/navigationId}}.</li>
+            <var>relevantGlobal</var>'s [=associated document=]'s [=most recent navigation=]'s {{PerformanceEntry/id}}.</li>
           </ol>
         </li>
         <li>Otherwise, set <var>newEntry</var>'s <a
@@ -742,11 +756,12 @@
       <p>To <dfn class="export">queue a navigation PerformanceEntry</dfn> (<var>newEntry</var>), run
       these steps:</p>
       <ol>
-        <li>Let <var>navigationId</var> be the result of running <a>generate a navigationId</a> for <var>newEntry</var>.</li>
+        <li>Let <var>id</var> be the result of running <a>generate an id</a> for <var>newEntry</var>.</li>
         <li>Let <var>relevantGlobal</var> be <var>newEntry</var>'s <a>relevant
         global object</a>.
         </li>
-        <li>Set <var>newEntry</var>'s {{PerformanceEntry/navigationId}} to <var>navigationId</var>.</li>
+        <li>Set <var>newEntry</var>'s {{PerformanceEntry/id}} to <var>id</var>.</li>
+        <li>Set <var>newEntry</var>'s {{PerformanceEntry/navigationId}} to <var>id</var>.</li>
         <li>If <var>relevantGlobal</var> has an [=associated document=]:
           <ol>
             <li>Set <var>relevantGlobal</var>'s [=associated document=]'s [=most recent navigation=] to <var>newEntry</var>.</li>
@@ -925,28 +940,26 @@
       </ol>
     </section>
     <section data-link-for="PerformanceEntry">
-      <h2>Generate a navigationId</h2>
-      <p>When asked to <dfn class="export">generate a navigationId</dfn> for a
+      <h2>Generate a Performance Entry id</h2>
+      <p>When asked to <dfn class="export">generate an id</dfn> for a
       <a>PerformanceEntry</a> <var>entry</a>, run the following steps:</p>
       <ol>
-        <li>Let <var>type</var> be <var>entry</var>'s <a>entryType</a>.</li>
-        <li>Let <var>startTime</var> be <var>entry</var>'s <a>startTime</a>.
-        <li>Let <var>timeString</var> be the result of calling
-        {{Number/toString(radix)}}(<var>startTime</var>, 10).
-        </li>
-        <li>If <var>timeString</var> contains the code point U+002E FULL STOP:
-          <ol>
-            <li><a>Assert</a>: <var>timeString</var> contains only one instance
-            of U+002E FULL STOP.</li>
-            <li><a>Assert</a>: <var>timeString</var> contains at least one code
-            point following the U+002E FULL STOP code point.</li>
-            <li>Truncate <var>timeString</var> after the first code point
-            following the U+002E FULL STOP code point.</li>
-          </ol>
-        </li>
-        <li>Return the [=string/concatenation=] of « <var>type</var>,
-        <var>timeString</var> » using U+002D HYPHEN-MINUS.</li>
+        <li>Let <var>relevantGlobal</var> be <var>entry</var>'s <a>relevant
+        global object</a>.
+        <li>Increase <var>relevantGlobal</var>'s <a>last performance entry
+        id</a> by a small number chosen by the user agent.</li>
+        <li>Return <var>relevantGlobal</var>'s <a>last performance entry id</a>.
       </ol>
+      <p>A user agent may choose to increase the <a>last performance entry
+      id</a>it by a small random integer every time. A user agent must not pick
+      a single global random integer and increase the <a>last performance entry
+      id</a> of all global objects by that amount because this could introduce
+      cross origin leaks.
+      </p>
+      <p class="note">The <a>last performance entry id</a> has an initial random
+      value, and is increased by a small number chosen by the user agent instead
+      of 1 to discourage developers from considering it as a counter of the
+      number of entries that have been generated in the web application.</p>
     </section>
   </section>
   <section id="privacy">
@@ -956,6 +969,15 @@
       refer to [[HR-TIME-3]] for privacy considerations of exposing high-resoluting timing
       information. Each new specification introducing new performance entries should have its own
       privacy considerations as well.</p>
+    <p>The <a>last performance entry id</a> is deliberately initialized to a
+      random value, and is incremented by another small value every time a new
+      {{PerformanceEntry}} is queued. User agents may choose to use a consistent
+      increment for all users, or may pick a different increment for each
+      <a>global object</a>, or may choose a new random increment for each
+      {{PerformanceEntry}}. However, in order to prevent cross-origin leaks, and
+      ensure that this does not enable fingerprinting, user agents must not just
+      pick a unique random integer, and use it as a consistent increment for all
+      {{PerformanceEntry}} objects across all <a>global objects</a>.
   </section>
   <section id="security">
     <h3>Security Considerations</h3>

--- a/index.html
+++ b/index.html
@@ -70,6 +70,9 @@
       </li>
       <li>Exposes {{PerformanceEntry}} in Web Workers [[WORKERS]];
       </li>
+      <li>Formalizes support for multiple navigation events over a document's
+      lifetime.
+      </li>
       <li>Adds support for {{PerformanceObserver}}.
       </li>
     </ul>
@@ -246,6 +249,7 @@
           <li>An integer <dfn>dropped entries count</dfn> that is initially 0.</li>
         </ul>
       </li>
+      <li>An integer <dfn>current navigation id</dfn> that is initially 0.</li>
     </ul>
     <p>In order to get the <dfn>relevant performance entry tuple</dfn>, given
     <var>entryType</var> and <var>globalObject</var> as input, run the
@@ -258,6 +262,17 @@
         map</var>, given <var>entryType</var> as the <a>key</a>.
       </li>
     </ol>
+    <p>The <a
+    href="https://html.spec.whatwg.org/#session-history-document-visibility-change-steps">session
+    history document visibility change steps</a> defined by this specification are:</p>
+    <ol>
+      <li>Increment <var>newDocument</var>'s [=relevant global object=]'s <a>current navigation
+      id</a>.</li>
+    </ol>
+    <p class="note">These steps will be called from [[HTML]]'s <a
+    href="https://html.spec.whatwg.org/#traverse-the-history">traverse the history</a>
+    algorithm whenever a document is restored from the bfcache, immediately before the
+    [=Window/pageshow=] event is fired.</p>
     <section data-dfn-for="Performance" data-link-for="Performance">
       <h2>Extensions to the {{Performance}} interface</h2>
       <p>This extends the {{Performance}} interface from [[HR-TIME-3]] and
@@ -308,6 +323,7 @@
         readonly    attribute DOMString           entryType;
         readonly    attribute DOMHighResTimeStamp startTime;
         readonly    attribute DOMHighResTimeStamp duration;
+        readonly    attribute unsigned long       navigationId;
         [Default] object toJSON();
       };</pre>
     <dl>
@@ -343,6 +359,12 @@
         the first recorded timestamp of this <a>PerformanceEntry</a>. If the
         duration concept doesn't apply, a performance metric may choose to
         return a `duration` of <code>0</code>.
+      </dd>
+      <dt><dfn>navigationId</dfn></dt>
+      <dd>
+        This attribute MUST return the value of the global object's <a>current
+        navigation id</a> at the time that this <a>PerformanceEntry</a> was
+        queued.
       </dd>
     </dl>
     <p>When <dfn>toJSON</dfn> is called, run [[WebIDL]]'s <a>default toJSON
@@ -672,6 +694,8 @@
         <li>Let <var>relevantGlobal</var> be <var>newEntry</var>'s <a>relevant
         global object</a>.
         </li>
+        <li>Set <var>newEntry</var>'s <a data-lt="PerformanceEntry.navigationId">navigationId</a>
+        to <var>relevantGlobal</var>'s <a>current navigation id</a>.</li>
         <li>For each <a>registered performance observer</a> <var>regObs</var> in
         <var>relevantGlobal</var>'s <a>list of registered performance observer objects</a>:
           <ol>


### PR DESCRIPTION
This adds the concept of a `current navigation id` to the global object, which starts at 0 and is incremented on every navigation event during a page's lifetime. This navigation id then gets exposed on PerformanceEntry objects, to allow those timeline entries to be segmented by user interaction.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clelland/performance-timeline/pull/192.html" title="Last updated on Nov 26, 2021, 5:37 PM UTC (6e5497e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/192/ca6936d...clelland:6e5497e.html" title="Last updated on Nov 26, 2021, 5:37 PM UTC (6e5497e)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clelland/performance-timeline/pull/192.html" title="Last updated on Oct 11, 2023, 3:33 PM UTC (1550c7d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/192/3984a34...clelland:1550c7d.html" title="Last updated on Oct 11, 2023, 3:33 PM UTC (1550c7d)">Diff</a>