### PR TITLE
Add some exports used elsewhere

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
         },
         {
           name: "Jatinder Mann",
-          url: "mailto: jmann@microsoft.com",
+          url: "mailto:jmann@microsoft.com",
           company: "Microsoft Corp.",
           note: "Until November 2014",
         },

--- a/index.html
+++ b/index.html
@@ -296,7 +296,7 @@
     </section>
   </section>
   <section data-dfn-for="PerformanceEntry" data-link-for="PerformanceEntry">
-    <h2>The <dfn class="export">PerformanceEntry</dfn> interface</h2>
+    <h2>The <dfn>PerformanceEntry</dfn> interface</h2>
     <p>The <a>PerformanceEntry</a> interface hosts the performance data of
     various metrics.</p>
     <pre class='idl'>
@@ -309,13 +309,13 @@
         [Default] object toJSON();
       };</pre>
     <dl>
-      <dt><dfn class="export">name</dfn></dt>
+      <dt><dfn>name</dfn></dt>
       <dd>
         This attribute MUST return an identifier for this
         <a>PerformanceEntry</a> object. This identifier does not have to be
         unique.
       </dd>
-      <dt><dfn class="export">entryType</dfn></dt>
+      <dt><dfn>entryType</dfn></dt>
       <dd>
         This attribute MUST return the type of the interface represented by
         this <a>PerformanceEntry</a> object.
@@ -328,12 +328,12 @@
         <!-- TODO: add long task spec reference -->
          and <code>"longtask"</code>.</p>
       </dd>
-      <dt><dfn class="export">startTime</dfn></dt>
+      <dt><dfn>startTime</dfn></dt>
       <dd>This attribute MUST return the time value of the first recorded
       timestamp of this performance metric. If the startTime concept doesn't
       apply, a performance metric may choose to return a `startTime` of
       <code>0</code>.</dd>
-      <dt><dfn class="export">duration</dfn></dt>
+      <dt><dfn>duration</dfn></dt>
       <dd>
         This attribute MUST return the time value of the duration of the entire
         event being recorded by this <a>PerformanceEntry</a>. Typically, this
@@ -348,7 +348,7 @@
   </section>
   <section data-link-for="PerformanceObserver" data-dfn-for=
   "PerformanceObserver">
-    <h2>The <dfn class="export">PerformanceObserver</dfn> interface</h2>
+    <h2>The <dfn>PerformanceObserver</dfn> interface</h2>
     <p>The <a>PerformanceObserver</a> interface can be used to observe the
     <a>Performance Timeline</a> to be notified of new performance metrics as
     they are recorded, and optionally buffered performance metrics.</p>
@@ -639,7 +639,7 @@
       strings among the <a href=
       "https://w3c.github.io/timing-entrytypes-registry/#registry">registry</a>
       that are supported for the global object, in alphabetical order.</p>
-      <p>When <dfn class="export">supportedEntryTypes</dfn>'s attribute getter is called, run
+      <p>When <dfn>supportedEntryTypes</dfn>'s attribute getter is called, run
       the following steps:</p>
       <ol>
         <li>Let <var>globalObject</var> be the <a data-cite=

--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
         {
           name: "Nicolás Peña Moreno",
           url: 'https://github.com/npm1',
-          mailto: "npm@chromium.org",
           company: "Google",
           companyURL: "https://www.google.com/",
           w3cid: "103755",
@@ -26,14 +25,13 @@
         {
           name: "Ilya Grigorik",
           url: "https://www.igvita.com/",
-          mailto: "igrigorik@gmail.com",
           company: "Google",
           companyURL: "https://www.google.com/",
           w3cid: "56102",
         },
         {
           name: "Jatinder Mann",
-          mailto: "jmann@microsoft.com",
+          url: "mailto: jmann@microsoft.com",
           company: "Microsoft Corp.",
           note: "Until November 2014",
         },
@@ -298,7 +296,7 @@
     </section>
   </section>
   <section data-dfn-for="PerformanceEntry" data-link-for="PerformanceEntry">
-    <h2>The <dfn>PerformanceEntry</dfn> interface</h2>
+    <h2>The <dfn class="export">PerformanceEntry</dfn> interface</h2>
     <p>The <a>PerformanceEntry</a> interface hosts the performance data of
     various metrics.</p>
     <pre class='idl'>
@@ -311,13 +309,13 @@
         [Default] object toJSON();
       };</pre>
     <dl>
-      <dt><dfn>name</dfn></dt>
+      <dt><dfn class="export">name</dfn></dt>
       <dd>
         This attribute MUST return an identifier for this
         <a>PerformanceEntry</a> object. This identifier does not have to be
         unique.
       </dd>
-      <dt><dfn>entryType</dfn></dt>
+      <dt><dfn class="export">entryType</dfn></dt>
       <dd>
         This attribute MUST return the type of the interface represented by
         this <a>PerformanceEntry</a> object.
@@ -330,12 +328,12 @@
         <!-- TODO: add long task spec reference -->
          and <code>"longtask"</code>.</p>
       </dd>
-      <dt><dfn>startTime</dfn></dt>
+      <dt><dfn class="export">startTime</dfn></dt>
       <dd>This attribute MUST return the time value of the first recorded
       timestamp of this performance metric. If the startTime concept doesn't
       apply, a performance metric may choose to return a `startTime` of
       <code>0</code>.</dd>
-      <dt><dfn>duration</dfn></dt>
+      <dt><dfn class="export">duration</dfn></dt>
       <dd>
         This attribute MUST return the time value of the duration of the entire
         event being recorded by this <a>PerformanceEntry</a>. Typically, this
@@ -350,7 +348,7 @@
   </section>
   <section data-link-for="PerformanceObserver" data-dfn-for=
   "PerformanceObserver">
-    <h2>The <dfn>PerformanceObserver</dfn> interface</h2>
+    <h2>The <dfn class="export">PerformanceObserver</dfn> interface</h2>
     <p>The <a>PerformanceObserver</a> interface can be used to observe the
     <a>Performance Timeline</a> to be notified of new performance metrics as
     they are recorded, and optionally buffered performance metrics.</p>
@@ -408,8 +406,8 @@
 </section>
     <section>
       <h2><dfn>observe()</dfn> method</h2>
-      <p>The <a>observe()</a> method instructs the user agent to <dfn>register
-      the observer</dfn> and must run these steps:</p>
+      <p>The <a>observe()</a> method instructs the user agent to register
+      the observer and must run these steps:</p>
       <ol data-link-for="PerformanceObserverInit">
         <li>Let <var>relevantGlobal</var> be <a>this</a>'s <a>relevant
         global object</a>.
@@ -641,7 +639,7 @@
       strings among the <a href=
       "https://w3c.github.io/timing-entrytypes-registry/#registry">registry</a>
       that are supported for the global object, in alphabetical order.</p>
-      <p>When <dfn>supportedEntryTypes</dfn>'s attribute getter is called, run
+      <p>When <dfn class="export">supportedEntryTypes</dfn>'s attribute getter is called, run
       the following steps:</p>
       <ol>
         <li>Let <var>globalObject</var> be the <a data-cite=
@@ -660,7 +658,7 @@
     <h2>Processing</h2>
     <section data-link-for="PerformanceObserver">
       <h2>Queue a <code>PerformanceEntry</code></h2>
-      <p>To <dfn>queue a PerformanceEntry</dfn> (<var>newEntry</var>), run
+      <p>To <dfn class="export">queue a PerformanceEntry</dfn> (<var>newEntry</var>), run
       these steps:</p>
       <ol>
         <li>Let <var>interested observers</var> be an initially empty set of
@@ -730,7 +728,7 @@
         </li>
         <li>
           <a>Queue a task</a> that consists of running the following substeps.
-          The <a>task source</a> for the queued task is the <dfn data-export="">performance
+          The <a>task source</a> for the queued task is the <dfn class="export">performance
           timeline task source</dfn>.
           <ol>
             <li>Unset <a>performance observer task queued flag</a> of
@@ -887,12 +885,21 @@
       </ol>
     </section>
   </section>
-  <section id="privacy-security">
-    <h3>Privacy and Security</h3>
-    <p>This specification extends the {{Performance}} interface defined by
-    [[HR-TIME-3]] and provides methods to queue and retrieve entries from the
-    <a>performance timeline</a>. Please refer to [[HR-TIME-3]] for privacy and
-    security considerations of exposing high-resoluting timing information.</p>
+  <section id="privacy">
+    <h3>Privacy Considerations</h3>
+    <p>This specification extends the {{Performance}} interface defined by [[HR-TIME-3]] and
+      provides methods to queue and retrieve entries from the <a>performance timeline</a>. Please
+      refer to [[HR-TIME-3]] for privacy considerations of exposing high-resoluting timing
+      information. Each new specification introducing new performance entries should have its own
+      privacy considerations as well.</p>
+  </section>
+  <section id="security">
+    <h3>Security Considerations</h3>
+    <p>This specification extends the {{Performance}} interface defined by [[HR-TIME-3]] and
+      provides methods to queue and retrieve entries from the <a>performance timeline</a>. Please
+      refer to [[HR-TIME-3]] for security considerations of exposing high-resoluting timing
+      information. Each new specification introducing new performance entries should have its own
+      security considerations as well.</p>
   </section>
   <section>
     <h2>Dependencies</h2>


### PR DESCRIPTION
This PR adds some export and applies some fixes for current warnings. When digging into https://github.com/WICG/element-timing/issues/67, I notice that some PerformanceTimeline objects are being manually imported. But this includes some IDL objects. I suspect I shouldn't have to do this?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/pull/197.html" title="Last updated on Jan 28, 2022, 2:46 PM UTC (5d5f115)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/197/ef65cde...5d5f115.html" title="Last updated on Jan 28, 2022, 2:46 PM UTC (5d5f115)">Diff</a>