### PR TITLE
Export performance entry buffer

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@
       "infra">map</a>'s <a data-cite="INFRA#map-value">value</a> is the
       following tuple:
         <ul>
-          <li>A <dfn>performance entry buffer</dfn> to store
+          <li>A <dfn class="export">performance entry buffer</dfn> to store
           <a>PerformanceEntry</a> objects, that is initially empty.
           </li>
           <li>An integer <dfn>maxBufferSize</dfn>, initialized to the


### PR DESCRIPTION
Fixes https://github.com/w3c/performance-timeline/issues/196


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/pull/198.html" title="Last updated on Jan 31, 2022, 1:15 PM UTC (68a7339)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/198/d1a88bf...68a7339.html" title="Last updated on Jan 31, 2022, 1:15 PM UTC (68a7339)">Diff</a>