### PR TITLE
Add support for accessing cross-frame entries.

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,31 +263,50 @@
       hosts performance related attributes and methods used to retrieve the
       performance metric data from the <a>Performance Timeline</a>.</p>
       <pre class="idl">
+      dictionary PerformanceEntryOptions {
+        DOMString type;
+        DOMString name;
+        boolean includeFrames;
+      };
+
       partial interface Performance {
-        PerformanceEntryList getEntries (optional boolean includeFrames = false);
-        PerformanceEntryList getEntriesByType (DOMString type, optional boolean includeFrames = false);
-        PerformanceEntryList getEntriesByName (DOMString name, optional DOMString type, optional boolean includeFrames = false);
+        PerformanceEntryList getEntries (optional PerformanceEntryOptions options = {});
+        PerformanceEntryList getEntriesByType (DOMString type);
+        PerformanceEntryList getEntriesByName (DOMString name, optional DOMString type);
       };
       typedef sequence&lt;PerformanceEntry&gt; PerformanceEntryList;
       </pre>
       <p>The <dfn>PerformanceEntryList</dfn> represents a sequence of
       <a>PerformanceEntry</a>, providing developers with all the convenience
       methods found on JavaScript arrays.</p>
+      <section data-dfn-for="PerformanceEntryOptions" data-link-for=
+      "PerformanceEntryOptions">
+        <h2><dfn>PerformanceEntryOptions</dfn> dictionary</h2>
+        <dl>
+          <dt><dfn>type</dfn></dt>
+          <dd>A single entry type to be retrieved.</dd>
+          <dt><dfn>name</dfn></dt>
+          <dd>A string representing the name of entries to be retrieved.</dd>
+          <dt><dfn>includeFrames</dfn></dt>
+          <dd>A flag to indicate whether entries from child frames should be
+          retrieved.</dd>
+        </dl>
+      </section>
       <section>
         <h2><dfn>getEntries()</dfn> method</h2>
         <p>Returns a <a>PerformanceEntryList</a> object returned by the
         <a>filter buffer map by name and type</a> algorithm with
-        <var>name</var> and <var>type</var> set to <code>null</code>, and
-        <var>includeFrames</var> set to the method's input
-        <code>includeFrames</code> parameter.</p>
+        <var>name</var>, <var>type</var> and <var>includeFrames</var> set to the
+        corresponding members of the method's input <code>options</code>
+        parameter.</p>
       </section>
       <section>
         <h2><dfn>getEntriesByType()</dfn> method</h2>
         <p>Returns a <a>PerformanceEntryList</a> object returned by <a>filter
         buffer map by name and type</a> algorithm with <var>name</var> set to
         <code>null</code>, <var>type</var> set to the method's input
-        <code>type</code> parameter, and <var>includeFrames</var> set to the
-        method's input <code>includeFrames</code> parameter.</p>
+        <code>type</code> parameter, and <var>includeFrames</var> set to
+        <code>false</code>.</p>
       </section>
       <section>
         <h2><dfn>getEntriesByName()</dfn> method</h2>
@@ -296,8 +315,7 @@
         the method's input <code>name</code> parameter, <var>type</var> set to
         either <code>null</code> if optional `entryType` is omitted, or the
         method's input <code>type</code> parameter otherwise, and
-        <var>includeFrames</var> set to the method's input
-        <code>includeFrames</code> parameter.</p>
+        <var>includeFrames</var> set to <code>false</code>.</p>
       </section>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         "check-punctuation": true,
       },
       doJsonLd: true,
-      xref: ["hr-time-3", "infra", "html", "dom"],
+      xref: ["hr-time-3", "infra", "html", "dom", "document-policy"],
       mdn: "performance-timeline",
     };
   </script>
@@ -69,6 +69,8 @@
       <li>Exposes {{PerformanceEntry}} in Web Workers [[WORKERS]];
       </li>
       <li>Adds support for {{PerformanceObserver}}.
+      </li>
+      <li>Adds support for cross-frame timeline sharing.
       </li>
     </ul>
   </section>
@@ -263,9 +265,9 @@
       performance metric data from the <a>Performance Timeline</a>.</p>
       <pre class="idl">
       partial interface Performance {
-        PerformanceEntryList getEntries ();
-        PerformanceEntryList getEntriesByType (DOMString type);
-        PerformanceEntryList getEntriesByName (DOMString name, optional DOMString type);
+        PerformanceEntryList getEntries (optional boolean includeFrames = false);
+        PerformanceEntryList getEntriesByType (DOMString type, optional boolean includeFrames = false);
+        PerformanceEntryList getEntriesByName (DOMString name, optional DOMString type, optional boolean includeFrames = false);
       };
       typedef sequence&lt;PerformanceEntry&gt; PerformanceEntryList;
       </pre>
@@ -276,22 +278,27 @@
         <h2><dfn>getEntries()</dfn> method</h2>
         <p>Returns a <a>PerformanceEntryList</a> object returned by the
         <a>filter buffer map by name and type</a> algorithm with
-        <var>name</var> and <var>type</var> set to <code>null</code>.</p>
+        <var>name</var> and <var>type</var> set to <code>null</code>, and
+        <var>includeFrames</var> set to the method's input
+        <code>includeFrames</code> parameter.</p>
       </section>
       <section>
         <h2><dfn>getEntriesByType()</dfn> method</h2>
         <p>Returns a <a>PerformanceEntryList</a> object returned by <a>filter
         buffer map by name and type</a> algorithm with <var>name</var> set to
-        <code>null</code>, and <var>type</var> set to the method's input
-        <code>type</code> parameter.</p>
+        <code>null</code>, <var>type</var> set to the method's input
+        <code>type</code> parameter, and <var>includeFrames</var> set to the
+        method's input <code>includeFrames</code> parameter.</p>
       </section>
       <section>
         <h2><dfn>getEntriesByName()</dfn> method</h2>
         <p>Returns a <a>PerformanceEntryList</a> object returned by <a>filter
         buffer map by name and type</a> algorithm with <var>name</var> set to
-        the method input <code>name</code> parameter, and <var>type</var> set
-        to <code>null</code> if optional `entryType` is omitted, or set to the
-        method's input <code>type</code> parameter otherwise.</p>
+        the method's input <code>name</code> parameter, <var>type</var> set to
+        either <code>null</code> if optional `entryType` is omitted, or the
+        method's input <code>type</code> parameter otherwise, and
+        <var>includeFrames</var> set to the method's input
+        <code>includeFrames</code> parameter.</p>
       </section>
     </section>
   </section>
@@ -306,6 +313,7 @@
         readonly    attribute DOMString           entryType;
         readonly    attribute DOMHighResTimeStamp startTime;
         readonly    attribute DOMHighResTimeStamp duration;
+        readonly    attribute object?             source;
         [Default] object toJSON();
       };</pre>
     <dl>
@@ -342,9 +350,16 @@
         duration concept doesn't apply, a performance metric may choose to
         return a `duration` of <code>0</code>.
       </dd>
+      <dt><dfn>source</dfn></dt>
+      <dd>
+        This attribute MUST return the [=global object=] for the realm in which
+        this <a>PerformanceEntry</a> was recorded.
+      </dd>
     </dl>
     <p>When <dfn>toJSON</dfn> is called, run [[WebIDL]]'s <a>default toJSON
     steps</a>.</p>
+    <p class="issue">The <a>toJSON</a> method should not attempt to serialize
+      the <a>source</a> object reference.</p>
   </section>
   <section data-link-for="PerformanceObserver" data-dfn-for=
   "PerformanceObserver">
@@ -403,7 +418,7 @@
         observer is observing when the <a>PerformanceObserver</a>'s <a>requires dropped entries</a>
         is set.</dd>
       </dl>
-</section>
+    </section>
     <section>
       <h2><dfn>observe()</dfn> method</h2>
       <p>The <a>observe()</a> method instructs the user agent to register
@@ -557,6 +572,7 @@
             sequence&lt;DOMString&gt; entryTypes;
             DOMString type;
             boolean buffered;
+            boolean includeFrames;
           };
           </pre>
         <dl>
@@ -574,6 +590,11 @@
           <dt><dfn>buffered</dfn></dt>
           <dd>A flag to indicate whether buffered entries should be queued into
           observer's buffer.</dd>
+        </dl>
+        <dl>
+          <dt><dfn>includeFrames</dfn></dt>
+          <dd>A flag to indicate whether entries from child frames should be
+          observed.</dd>
         </dl>
       </section>
       <section data-dfn-for="PerformanceObserverEntryList" data-link-for=
@@ -658,8 +679,8 @@
     <h2>Processing</h2>
     <section data-link-for="PerformanceObserver">
       <h2>Queue a <code>PerformanceEntry</code></h2>
-      <p>To <dfn class="export">queue a PerformanceEntry</dfn> (<var>newEntry</var>), run
-      these steps:</p>
+      <p>To <dfn class="export">queue a PerformanceEntry</dfn> (<var>newEntry</var>)
+      with optional <a>boolean</a> <var>traverse</var>, run these steps:</p>
       <ol>
         <li>Let <var>interested observers</var> be an initially empty set of
         <a>PerformanceObserver</a> objects.
@@ -669,6 +690,8 @@
         </li>
         <li>Let <var>relevantGlobal</var> be <var>newEntry</var>'s <a>relevant
         global object</a>.
+        </li>
+        <li>Set <var>newEntry</var>'s {{PerformanceEntry/source}} to <var>relevantGlobal</var>.
         </li>
         <li>For each <a>registered performance observer</a> <var>regObs</var> in
         <var>relevantGlobal</var>'s <a>list of registered performance observer objects</a>:
@@ -713,6 +736,25 @@
         <li><a>Queue the PerformanceObserver task</a> with
         <var>relevantGlobal</var> as input.
         </li>
+        <li>If <var>traverse</var> is true:
+          <ol>
+            <li>Let <var>origins</var> be the result of calling
+            [=get-policy-value=] with `<a>share-performance-timeline-with</a>`
+            and <var>relevantGlobal</var>'s <a>active document</a>.</li>
+            <li>For each <a>browsing context</a> <var>context</var> which is an
+            <a>ancestor browsing context</a> of <var>relevantGlobal</var>'s
+            <a>browsing context</a>:
+              <ol>
+                <li>If <var>origins</var> contains the token `*`, or
+                <var>origins</var> contains <var>context</var>'s <a>origin</a>,
+                <a>Queue a global task</a> on the <a>performance timeline task
+                source</a> with <var>context</var>'s [=browsing context/active
+                window=] to <a>queue a PerformanceEntry</a> with
+                <var>newEntry</var>.</li>
+             </ol>
+             </li>
+           </ol>
+         </li>
       </ol>
     </section>
     <section data-link-for="PerformanceObserver">
@@ -801,8 +843,8 @@
     <section data-link-for="PerformanceEntry">
       <h2>Filter buffer map by name and type</h2>
       <p>When asked to run the <dfn>filter buffer map by name and type</dfn>
-      algorithm with optional <var>name</var> and <var>type</var>, run the
-      following steps:</p>
+      algorithm with optional <var>name</var>, <var>type</var>, and
+      <var>includeFrames</var>, run the following steps:</p>
       <ol>
         <li>Let <var>result</var> be an initially empty <a>list</a>.
         </li>
@@ -827,8 +869,8 @@
             continue to the next <var>tuple</var>.
             </li>
             <li>Let <var>entries</var> be the result of running <a>filter
-            buffer by name and type</a> with <var>buffer</var>, <var>name</var>
-            and <var>type</var> as inputs.
+            buffer by name and type</a> with <var>buffer</var>, <var>name</var>,
+            <var>type</var> and <var>includeFrames</var> as inputs.
             </li>
             <li>For each <var>entry</var> in <var>entries</var>,
             [=list/append=] <var>entry</var> to <var>result</var>.</li>
@@ -843,14 +885,17 @@
     <section data-link-for="PerformanceEntry">
       <h2>Filter buffer by name and type</h2>
       <p>When asked to run the <dfn>filter buffer by name and type</dfn>
-      algorithm, with <var>buffer</var>, <var>name</var>, and <var>type</var>
-      as inputs, run the following steps:</p>
+      algorithm, with <var>buffer</var>, <var>name</var>, <var>type</var> and
+      <var>includeFrames</var> as inputs, run the following steps:</p>
       <ol>
         <li>Let <var>result</var> be an initially empty <a>list</a>.
         </li>
         <li>For each <a>PerformanceEntry</a> <var>entry</var> in
         <var>buffer</var>, run the following steps:
           <ol>
+            <li>If <var>includeFrames</var> is not true and <a>this</a>'s
+            <a>relevant global object</a> is not the same as <var>entry</var>'s
+            {{PerformanceEntry/source}}, continue to next <var>entry</var>.
             <li>If <var>type</var> is not null and if <var>type</var> is not
             <a data-cite=INFRA#string-is>identical to</a> <var>entry</var>'s
             <code>entryType</code> attribute, continue to next <var>entry</var>.
@@ -883,6 +928,19 @@
         <li>Increase <var>tuple</var>'s <a>dropped entries count</a> by 1.</li>
         <li>Return true.</li>
       </ol>
+    </section>
+  </section>
+  <section id="integratioons">
+    <h3>Integrations with other Specifications</h3>
+    <section id="permissions-policy-integration">
+      <h3>Integration with Document Policy</h3>
+      <p>This specification defines a [=configuration point=] with the name
+      <code><dfn>share-performance-timeline-with</dfn></code>. Its type is
+      <code>set</code>, and its default value is the empty set.</p>
+      <p>Set members must be strings representing origins, or the token `*`,
+        representing all origins.</p>
+      <p class="issue">This integration requires a currently-non-specified
+        "set" type and "string" type in Document Policy.</p>
     </section>
   </section>
   <section id="privacy">


### PR DESCRIPTION
This adds a Document-Policy configuration point for documents, named "share-performance-timeline-with", which acceps a set of origins. If it is non-empty, then ancestor frames whose origins are contained in that set can access the timeline entries of the child frame, either through a PerformanceObserver, or by passing a boolean flag into the various getEntries methods.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clelland/performance-timeline/pull/202.html" title="Last updated on Jan 10, 2023, 8:00 PM UTC (2854086)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/202/3984a34...clelland:2854086.html" title="Last updated on Jan 10, 2023, 8:00 PM UTC (2854086)">Diff</a>