### PR TITLE
Remove PerformanceEntry.id and rephrase id generation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
     and be notified of new performance metrics and, optionally, previously
     buffered performance metrics of specified type, via the
     <a>PerformanceObserver</a> interface.</p>
-    <p>The <a>PerformanceObserver</a> interface was added 
+    <p>The <a>PerformanceObserver</a> interface was added
     and is designed to address limitations of the buffer-based
     approach shown in the first example. By using the PerformanceObserver
     interface, the application can:</p>
@@ -315,7 +315,7 @@
         readonly    attribute DOMString           entryType;
         readonly    attribute DOMHighResTimeStamp startTime;
         readonly    attribute DOMHighResTimeStamp duration;
-        readonly    attribute long                navigationId;
+        readonly    attribute unsigned long       navigationId;
         [Default] object toJSON();
       };</pre>
     <dl>

--- a/index.html
+++ b/index.html
@@ -247,15 +247,12 @@
           <li>An integer <dfn>dropped entries count</dfn> that is initially 0.</li>
         </ul>
       </li>
-      <li>An integer <dfn>last performance entry id</dfn> that is initially set
-      to a random integer between 100 and 10000.
+      <li>An integer <dfn>current navigation id</dfn>, which is initially 0.
       </li>
     </ul>
     <p>Each <a>Document</a> has:</p>
     <ul>
-      <li>A <dfn>most recent navigation</dfn>, which is a <a>PerformanceEntry</a>,
-      initially unset.
-      </li>
+      An integer <dfn>current navigation id</dfn>, which is initially 0.
     </ul>
     <p>In order to get the <dfn>relevant performance entry tuple</dfn>, given
     <var>entryType</var> and <var>globalObject</var> as input, run the
@@ -318,7 +315,7 @@
         readonly    attribute DOMString           entryType;
         readonly    attribute DOMHighResTimeStamp startTime;
         readonly    attribute DOMHighResTimeStamp duration;
-        readonly    attribute unsigned long long  navigationId;
+        readonly    attribute long                navigationId;
         [Default] object toJSON();
       };</pre>
     <dl>
@@ -331,9 +328,8 @@
       <dd>
         This attribute must return the value it is initialized to.
 
-        <p class="note">All `entryType` values are defined in the
-        relevant<a href=
-        "https://w3c.github.io/timing-entrytypes-registry/#registry">registry</a>.
+        <p class="note">All `entryType` values are defined in the relevant
+        <a href="https://w3c.github.io/timing-entrytypes-registry/#registry">registry</a>.
         Examples include: <code>"mark"</code> and <code>"measure"</code>
         [[USER-TIMING-2]], <code>"navigation"</code> [[NAVIGATION-TIMING-2]],
         and <code>"resource"</code> [[RESOURCE-TIMING-2]].</p>
@@ -686,21 +682,20 @@
         <li>Let <var>interested observers</var> be an initially empty set of
         <a>PerformanceObserver</a> objects.
         </li>
-        <li>Let <var>entryType</var> be <var>newEntry</var>’s <a data-lt=
+        <li>Let <var>entryType</var> be <var>newEntry</var>'s <a data-lt=
         "PerformanceEntry.entryType">entryType</a> value.
         </li>
         <li>Let <var>relevantGlobal</var> be <var>newEntry</var>'s <a>relevant
         global object</a>.
         </li>
-        <li>If <var>relevantGlobal</var> has an [=associated document=]:
-          <ol>
-            <li>Set <var>newEntry</var>'s <a
-            data-lt="PerformanceEntry.navigationId">navigationId</a> to the value of
-            <var>relevantGlobal</var>'s [=associated document=]'s [=most recent navigation=]'s {{PerformanceEntry/navigationId}}.</li>
-          </ol>
+        <li>If the <code>PerformanceEntry</code> to be queued is a navigation
+          entry (in other words, <code>entryType=='navigation'</code>), then
+          let <var>navigationId</var> be the result of running
+          <a>generate a navigation id</a>. Otherwise, let <var>navigationId</var>
+          be the <var>relevantGlobal</var>’s <var>current navigation id</var>.
         </li>
-        <li>Otherwise, set <var>newEntry</var>'s <a
-        data-lt="PerformanceEntry.navigationId">navigationId</a> to null.</li>
+        <li>Set <var>newEntry</var>'s <a
+        data-lt="PerformanceEntry.navigationId">navigationId</a> to <var>navigationId</var>.</li>
         <li>For each <a>registered performance observer</a> <var>regObs</var> in
         <var>relevantGlobal</var>'s <a>list of registered performance observer objects</a>:
           <ol>
@@ -744,24 +739,6 @@
         <li><a>Queue the PerformanceObserver task</a> with
         <var>relevantGlobal</var> as input.
         </li>
-      </ol>
-    </section>
-    <section data-link-for="PerformanceObserver">
-      <h2>Queue a navigation <code>PerformanceEntry</code></h2>
-      <p>To <dfn class="export">queue a navigation PerformanceEntry</dfn> (<var>newEntry</var>), run
-      these steps:</p>
-      <ol>
-        <li>Let <var>id</var> be the result of running <a>generate a navigation id</a> for <var>newEntry</var>.</li>
-        <li>Let <var>relevantGlobal</var> be <var>newEntry</var>'s <a>relevant
-        global object</a>.
-        </li>
-        <li>Set <var>newEntry</var>'s {{PerformanceEntry/navigationId}} to <var>id</var>.</li>
-        <li>If <var>relevantGlobal</var> has an [=associated document=]:
-          <ol>
-            <li>Set <var>relevantGlobal</var>'s [=associated document=]'s [=most recent navigation=] to <var>newEntry</var>.</li>
-          </ol>
-        </li>
-        <li><a>Queue a PerformanceEntry</a> with <var>newEntry</var> as input.</li>
       </ol>
     </section>
     <section data-link-for="PerformanceObserver">
@@ -940,13 +917,18 @@
       <ol>
         <li>Let <var>relevantGlobal</var> be <var>entry</var>'s <a>relevant
             global object</a>.
-        <li>If <var>relevantGlobal</var> has an [=associated document=]
-          with a [=most recent navigation=]:
-          <ol>
-            <li>Return the sum of the [=most recent navigation=]'s
-              <var>navigationId</var> and a small integer.
-          </ol>
-        <li>Otherwise return a random integer.
+        <li>Let <var>relevantDoc</var> be <var>relevantGlobal</var>'s [=associated document=], or null.
+        <li>If <var>relevantGlobal</var>'s [=current navigation id=] is 0 (the initial value),
+          of if <var>relevantDoc</var> is null,
+          or if <var>relevantDoc</var> is not null and <var>relevantGlobal</var>'s
+          [=current navigation id=] differs from <var>doc</var>'s [=current navigation id=],
+          then let <var>navigationId</var> be a random integer between 100 and 10000000.
+        <li>Otherwise, let <var>navigationId</var> be <var>relevantGlobal</var>'s [=current navigation id=]
+          plus a small integer.
+        <li>Set <var>relevantGlobal</var>'s [=current navigation id=] to <var>navigationId</var>.
+        <li>If <var>relevantDoc</var> is not null, set <var>relevantDoc</var>'s [=current navigation id=]
+          to <var>navigationId</var>.
+        <li>Return <var>navigationId</var>.
       </ol>
       <p class="note">Sequences of navigation ids that are associated with
         the same document can be used to establish order, by sorting by
@@ -955,6 +937,8 @@
         as small number as opposed to 1, to discourage developers from considering
         navigation ids as a counter of the number of entries that have been generated
         in the web application.</p>
+      <p class="note">To avoid integer overflow, the same-document mechanism may revert to assign
+        a random integer between 10 and 10000000, but this is expected to be extremeley rare.</p>
     </section>
   </section>
   <section id="privacy">

--- a/index.html
+++ b/index.html
@@ -252,7 +252,7 @@
     </ul>
     <p>Each <a>Document</a> has:</p>
     <ul>
-      An integer <dfn>current navigation id</dfn>, which is initially 0.
+      An integer <dfn>current document navigation id</dfn>, which is initially 0.
     </ul>
     <p>In order to get the <dfn>relevant performance entry tuple</dfn>, given
     <var>entryType</var> and <var>globalObject</var> as input, run the
@@ -691,7 +691,9 @@
         <li>If the <code>PerformanceEntry</code> to be queued is a navigation
           entry (in other words, <code>entryType=='navigation'</code>), then
           let <var>navigationId</var> be the result of running
-          <a>generate a navigation id</a>. Otherwise, let <var>navigationId</var>
+          <a>generate a navigation id</a>.
+        </li>
+        <li>Otherwise, let <var>navigationId</var>
           be the <var>relevantGlobal</var>’s <var>current navigation id</var>.
         </li>
         <li>Set <var>newEntry</var>'s <a
@@ -921,12 +923,12 @@
         <li>If <var>relevantGlobal</var>'s [=current navigation id=] is 0 (the initial value),
           of if <var>relevantDoc</var> is null,
           or if <var>relevantDoc</var> is not null and <var>relevantGlobal</var>'s
-          [=current navigation id=] differs from <var>doc</var>'s [=current navigation id=],
+          [=current navigation id=] differs from <var>doc</var>'s [=current document navigation id=],
           then let <var>navigationId</var> be a random integer between 100 and 10000000.
         <li>Otherwise, let <var>navigationId</var> be <var>relevantGlobal</var>'s [=current navigation id=]
           plus a small integer.
         <li>Set <var>relevantGlobal</var>'s [=current navigation id=] to <var>navigationId</var>.
-        <li>If <var>relevantDoc</var> is not null, set <var>relevantDoc</var>'s [=current navigation id=]
+        <li>If <var>relevantDoc</var> is not null, set <var>relevantDoc</var>'s [=current document navigation id=]
           to <var>navigationId</var>.
         <li>Return <var>navigationId</var>.
       </ol>

--- a/index.html
+++ b/index.html
@@ -913,7 +913,7 @@
     <section data-link-for="PerformanceEntry">
       <h2>Generate a Navigation id</h2>
       <p>When asked to <dfn class="export">generate a navigation id</dfn> for a navigation
-      <a>PerformanceEntry</a> <var>entry</a>, run the following steps:</p>
+      <a>PerformanceEntry</a> <var>entry</var>, run the following steps:</p>
       <ol>
         <li>Let <var>relevantGlobal</var> be <var>entry</var>'s <a>relevant
             global object</a>.
@@ -948,7 +948,7 @@
       refer to [[HR-TIME-3]] for privacy considerations of exposing high-resoluting timing
       information. Each new specification introducing new performance entries should have its own
       privacy considerations as well.</p>
-    <p>The <a>last navigation id</a> is deliberately initialized to a
+    <p>The <a>current navigation id</a> is deliberately initialized to a
       random value, and is incremented by another small value every time a new
       navigation
       {{PerformanceEntry}} is queued. User agents may choose to use a consistent

--- a/index.html
+++ b/index.html
@@ -314,7 +314,6 @@
     <pre class='idl'>
       [Exposed=(Window,Worker)]
       interface PerformanceEntry {
-        readonly    attribute unsigned long long  id;
         readonly    attribute DOMString           name;
         readonly    attribute DOMString           entryType;
         readonly    attribute DOMHighResTimeStamp startTime;
@@ -680,16 +679,28 @@
   <section>
     <h2>Processing</h2>
     <section data-link-for="PerformanceObserver">
+      <h2>Queue a navigation <code>PerformanceEntry</code></h2>
+      <p>To <dfn class="export">queue a navigation PerformanceEntry</dfn> (<var>newEntry</var>), run
+      these steps:</p>
+      <ol>
+        <li>Let <var>id</var> be the result of running <a>generate a navigation id</a> for <var>newEntry</var>.</li>
+        <li>Let <var>relevantGlobal</var> be <var>newEntry</var>'s <a>relevant
+        global object</a>.
+        </li>
+        <li>Set <var>newEntry</var>'s {{PerformanceEntry/navigationId}} to <var>id</var>.</li>
+        <li>If <var>relevantGlobal</var> has an [=associated document=]:
+          <ol>
+            <li>Set <var>relevantGlobal</var>'s [=associated document=]'s [=most recent navigation=] to <var>newEntry</var>.</li>
+          </ol>
+        </li>
+        <li><a>Queue a PerformanceEntry</a> with <var>newEntry</var> as input.</li>
+      </ol>
+    </section>
+    <section data-link-for="PerformanceObserver">
       <h2>Queue a <code>PerformanceEntry</code></h2>
       <p>To <dfn class="export">queue a PerformanceEntry</dfn> (<var>newEntry</var>), run
       these steps:</p>
       <ol>
-        <li>If <var>newEntry</var>'s {{PerformanceEntry/id}} is unset:
-          <ol>
-            <li>Let <var>id</var> be the result of running <a>generate an id</a> for <var>newEntry</var>.</li>
-            <li>Set <var>newEntry</var>'s {{PerformanceEntry/id}} to <var>id</var>.</li>
-          </ol>
-        </li>
         <li>Let <var>interested observers</var> be an initially empty set of
         <a>PerformanceObserver</a> objects.
         </li>
@@ -703,7 +714,7 @@
           <ol>
             <li>Set <var>newEntry</var>'s <a
             data-lt="PerformanceEntry.navigationId">navigationId</a> to the value of
-            <var>relevantGlobal</var>'s [=associated document=]'s [=most recent navigation=]'s {{PerformanceEntry/id}}.</li>
+            <var>relevantGlobal</var>'s [=associated document=]'s [=most recent navigation=]'s {{PerformanceEntry/navigationId}}.</li>
           </ol>
         </li>
         <li>Otherwise, set <var>newEntry</var>'s <a
@@ -751,25 +762,6 @@
         <li><a>Queue the PerformanceObserver task</a> with
         <var>relevantGlobal</var> as input.
         </li>
-      </ol>
-    </section>
-    <section data-link-for="PerformanceObserver">
-      <h2>Queue a navigation <code>PerformanceEntry</code></h2>
-      <p>To <dfn class="export">queue a navigation PerformanceEntry</dfn> (<var>newEntry</var>), run
-      these steps:</p>
-      <ol>
-        <li>Let <var>id</var> be the result of running <a>generate an id</a> for <var>newEntry</var>.</li>
-        <li>Let <var>relevantGlobal</var> be <var>newEntry</var>'s <a>relevant
-        global object</a>.
-        </li>
-        <li>Set <var>newEntry</var>'s {{PerformanceEntry/id}} to <var>id</var>.</li>
-        <li>Set <var>newEntry</var>'s {{PerformanceEntry/navigationId}} to <var>id</var>.</li>
-        <li>If <var>relevantGlobal</var> has an [=associated document=]:
-          <ol>
-            <li>Set <var>relevantGlobal</var>'s [=associated document=]'s [=most recent navigation=] to <var>newEntry</var>.</li>
-          </ol>
-        </li>
-        <li><a>Queue a PerformanceEntry</a> with <var>newEntry</var> as input.</li>
       </ol>
     </section>
     <section data-link-for="PerformanceObserver">
@@ -942,26 +934,27 @@
       </ol>
     </section>
     <section data-link-for="PerformanceEntry">
-      <h2>Generate a Performance Entry id</h2>
-      <p>When asked to <dfn class="export">generate an id</dfn> for a
+      <h2>Generate a Navigation id</h2>
+      <p>When asked to <dfn class="export">generate a navigation id</dfn> for a navigation
       <a>PerformanceEntry</a> <var>entry</a>, run the following steps:</p>
       <ol>
         <li>Let <var>relevantGlobal</var> be <var>entry</var>'s <a>relevant
-        global object</a>.
-        <li>Increase <var>relevantGlobal</var>'s <a>last performance entry
-        id</a> by a small number chosen by the user agent.</li>
-        <li>Return <var>relevantGlobal</var>'s <a>last performance entry id</a>.
+            global object</a>.
+        <li>If <var>relevantGlobal</var> has an [=associated document=]
+          with a [=most recent navigation=]:
+          <ol>
+            <li>Return the sum of the [=most recent navigation=]'s
+              <var>navigationId</var> and a small integer.
+          </ol>
+        <li>Otherwise return a random integer.
       </ol>
-      <p>A user agent may choose to increase the <a>last performance entry
-      id</a>it by a small random integer every time. A user agent must not pick
-      a single global random integer and increase the <a>last performance entry
-      id</a> of all global objects by that amount because this could introduce
-      cross origin leaks.
-      </p>
-      <p class="note">The <a>last performance entry id</a> has an initial random
-      value, and is increased by a small number chosen by the user agent instead
-      of 1 to discourage developers from considering it as a counter of the
-      number of entries that have been generated in the web application.</p>
+      <p class="note">Sequences of navigation ids that are associated with
+        the same document can be used to establish order, by sorting by
+        navigation id.</p>
+      <p calss="note">The increcase between same-document navigation ids is
+        as small number as opposed to 1, to discourage developers from considering
+        navigation ids as a counter of the number of entries that have been generated
+        in the web application.</p>
     </section>
   </section>
   <section id="privacy">
@@ -971,8 +964,9 @@
       refer to [[HR-TIME-3]] for privacy considerations of exposing high-resoluting timing
       information. Each new specification introducing new performance entries should have its own
       privacy considerations as well.</p>
-    <p>The <a>last performance entry id</a> is deliberately initialized to a
+    <p>The <a>last navigation id</a> is deliberately initialized to a
       random value, and is incremented by another small value every time a new
+      navigation
       {{PerformanceEntry}} is queued. User agents may choose to use a consistent
       increment for all users, or may pick a different increment for each
       <a>global object</a>, or may choose a new random increment for each

--- a/index.html
+++ b/index.html
@@ -951,7 +951,7 @@
       <p class="note">Sequences of navigation ids that are associated with
         the same document can be used to establish order, by sorting by
         navigation id.</p>
-      <p calss="note">The increcase between same-document navigation ids is
+      <p class="note">The increcase between same-document navigation ids is
         as small number as opposed to 1, to discourage developers from considering
         navigation ids as a counter of the number of entries that have been generated
         in the web application.</p>

--- a/index.html
+++ b/index.html
@@ -925,8 +925,8 @@
           or if <var>relevantDoc</var> is not null and <var>relevantGlobal</var>'s
           [=current navigation id=] differs from <var>doc</var>'s [=current document navigation id=],
           then let <var>navigationId</var> be a random integer between 100 and 10000000.
-        <li>Otherwise, let <var>navigationId</var> be <var>relevantGlobal</var>'s [=current navigation id=]
-          plus a small integer.
+        <li>Otherwise, let <var>navigationId</var> be the sum of <var>relevantGlobal</var>'s
+          [=current navigation id=] and a small integer.
         <li>Set <var>relevantGlobal</var>'s [=current navigation id=] to <var>navigationId</var>.
         <li>If <var>relevantDoc</var> is not null, set <var>relevantDoc</var>'s [=current document navigation id=]
           to <var>navigationId</var>.

--- a/index.html
+++ b/index.html
@@ -252,7 +252,9 @@
     </ul>
     <p>Each <a>Document</a> has:</p>
     <ul>
-      An integer <dfn>current document navigation id</dfn>, which is initially 0.
+      <li>
+        An integer <dfn>current document navigation id</dfn>, which is initially 0.
+      </li>
     </ul>
     <p>In order to get the <dfn>relevant performance entry tuple</dfn>, given
     <var>entryType</var> and <var>globalObject</var> as input, run the

--- a/index.html
+++ b/index.html
@@ -679,24 +679,6 @@
   <section>
     <h2>Processing</h2>
     <section data-link-for="PerformanceObserver">
-      <h2>Queue a navigation <code>PerformanceEntry</code></h2>
-      <p>To <dfn class="export">queue a navigation PerformanceEntry</dfn> (<var>newEntry</var>), run
-      these steps:</p>
-      <ol>
-        <li>Let <var>id</var> be the result of running <a>generate a navigation id</a> for <var>newEntry</var>.</li>
-        <li>Let <var>relevantGlobal</var> be <var>newEntry</var>'s <a>relevant
-        global object</a>.
-        </li>
-        <li>Set <var>newEntry</var>'s {{PerformanceEntry/navigationId}} to <var>id</var>.</li>
-        <li>If <var>relevantGlobal</var> has an [=associated document=]:
-          <ol>
-            <li>Set <var>relevantGlobal</var>'s [=associated document=]'s [=most recent navigation=] to <var>newEntry</var>.</li>
-          </ol>
-        </li>
-        <li><a>Queue a PerformanceEntry</a> with <var>newEntry</var> as input.</li>
-      </ol>
-    </section>
-    <section data-link-for="PerformanceObserver">
       <h2>Queue a <code>PerformanceEntry</code></h2>
       <p>To <dfn class="export">queue a PerformanceEntry</dfn> (<var>newEntry</var>), run
       these steps:</p>
@@ -762,6 +744,24 @@
         <li><a>Queue the PerformanceObserver task</a> with
         <var>relevantGlobal</var> as input.
         </li>
+      </ol>
+    </section>
+    <section data-link-for="PerformanceObserver">
+      <h2>Queue a navigation <code>PerformanceEntry</code></h2>
+      <p>To <dfn class="export">queue a navigation PerformanceEntry</dfn> (<var>newEntry</var>), run
+      these steps:</p>
+      <ol>
+        <li>Let <var>id</var> be the result of running <a>generate a navigation id</a> for <var>newEntry</var>.</li>
+        <li>Let <var>relevantGlobal</var> be <var>newEntry</var>'s <a>relevant
+        global object</a>.
+        </li>
+        <li>Set <var>newEntry</var>'s {{PerformanceEntry/navigationId}} to <var>id</var>.</li>
+        <li>If <var>relevantGlobal</var> has an [=associated document=]:
+          <ol>
+            <li>Set <var>relevantGlobal</var>'s [=associated document=]'s [=most recent navigation=] to <var>newEntry</var>.</li>
+          </ol>
+        </li>
+        <li><a>Queue a PerformanceEntry</a> with <var>newEntry</var> as input.</li>
       </ol>
     </section>
     <section data-link-for="PerformanceObserver">


### PR DESCRIPTION
- Removing PerformanceEntry.id, since it's shadowed by PerformanceElementTiming.id, see https://github.com/w3c/performance-timeline/issues/218
- Rephrasing how navigation ids are generated:
  - no more mention of id, but the mechanism is the same as before, a random navigation id for each new document, which is then incremented for navigations that don't change the document
  - changes the order of the sections for queing so that it first talks about navigation performance entries, since these change the navigation ids, and only after that other entries


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/powdercloud/performance-timeline/pull/219.html" title="Last updated on May 30, 2025, 11:38 PM UTC (4524f6c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/219/7074783...powdercloud:4524f6c.html" title="Last updated on May 30, 2025, 11:38 PM UTC (4524f6c)">Diff</a>