### PR TITLE
Fix broken anchor references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -218,7 +218,7 @@ urlPrefix: https://w3c.github.io/timing-entrytypes-registry/; spec: TIMING-ENTRY
   [=map/value=] is the
   following tuple:
     <ul>
-      <li>A <dfn data-export>performance entry buffer</dfn> to store
+      <li>A <dfn data-export oldids="dfn-performance-entry-buffer">performance entry buffer</dfn> to store
       {{PerformanceEntry}} objects, that is initially empty.
       </li>
       <li>An integer <dfn>maxBufferSize</dfn>, initialized to the
@@ -336,7 +336,7 @@ steps=].</p>
 <p>A {{PerformanceEntry}} has a {{DOMHighResTimeStamp}} <dfn data-export>end time</dfn>,
 initially 0.
 
-<p>To <dfn data-export>initialize a PerformanceEntry</dfn> <var>entry</var> given a {{DOMHighResTimeStamp}} <var>startTime</var>,
+<p>To <dfn data-export oldids="dfn-initialize-a-performanceentry">initialize a PerformanceEntry</dfn> <var>entry</var> given a {{DOMHighResTimeStamp}} <var>startTime</var>,
 a <code>DOMString</code> <var>entryType</var>, a <code>DOMString</code> <var ignore>name</var>, and an optional {{DOMHighResTimeStamp}} <var>endTime</var> (default <code>0</code>):
 
 <ol>
@@ -355,7 +355,7 @@ they are recorded, and optionally buffered performance metrics.</p>
 <ul>
   <li>A {{PerformanceObserverCallback}} <dfn>observer callback</dfn> set on creation.
   </li>
-  <li>A {{PerformanceEntryList}} object called the <dfn>observer
+  <li>A {{PerformanceEntryList}} object called the <dfn oldids="dfn-observer-buffer">observer
   buffer</dfn> that is initially empty.
   </li>
   <li>A <code>DOMString</code> <dfn>observer type</dfn> which is initially
@@ -366,8 +366,8 @@ they are recorded, and optionally buffered performance metrics.</p>
 {{PerformanceObserver}} object with its [=observer callback=]
 set to <var ignore>callback</var> and then return it.</p>
 <p>A <dfn>registered performance observer</dfn> is a [=struct=]
-consisting of an <dfn>observer</dfn> member (a {{PerformanceObserver}}
-object) and an <dfn>options list</dfn> member (a list of
+consisting of an <dfn oldids="dfn-observer">observer</dfn> member (a {{PerformanceObserver}}
+object) and an <dfn oldids="dfn-options-list">options list</dfn> member (a list of
 {{PerformanceObserverInit}} dictionaries).</p>
 <pre class="idl">
 callback PerformanceObserverCallback = undefined (PerformanceObserverEntryList entries,


### PR DESCRIPTION
After the Bikeshed conversion, some anchor IDs changed (e.g. `dfn-` prefixes dropped). This adds `oldids` attributes and fixes link-defaults so cross-spec references resolve correctly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/pull/227.html" title="Last updated on Mar 24, 2026, 10:13 AM UTC (7c0a5ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/performance-timeline/227/ddbb2dd...7c0a5ce.html" title="Last updated on Mar 24, 2026, 10:13 AM UTC (7c0a5ce)">Diff</a>